### PR TITLE
Add light theme, timing controls, and scalable AI improvements

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -1,8 +1,11 @@
-﻿<Application x:Class="Caro_game.App"
+<Application x:Class="Caro_game.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-            
     <Application.Resources>
-        <SolidColorBrush x:Key="Primary" Color="#3B82F6"/>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/Themes/DarkTheme.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/Converter/BoolToBrushConverter.cs
+++ b/Converter/BoolToBrushConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
 
@@ -7,14 +8,22 @@ namespace Caro_game.Converters
 {
     public class BoolToBrushConverter : IValueConverter
     {
-        public Brush TrueBrush { get; set; } = Brushes.Gold;
-        public Brush FalseBrush { get; set; } = new SolidColorBrush(Color.FromRgb(15, 23, 42));
+        public Brush? TrueBrush { get; set; }
+        public Brush? FalseBrush { get; set; }
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
+            var resources = Application.Current?.Resources;
+
+            var winningBrush = TrueBrush ?? resources?["WinningCellBrush"] as Brush ?? Brushes.Gold;
+            var regularBrush = FalseBrush ?? resources?["CellBackgroundBrush"] as Brush ?? new SolidColorBrush(Color.FromRgb(15, 23, 42));
+
             if (value is bool b && b)
-                return TrueBrush;
-            return FalseBrush;
+            {
+                return winningBrush;
+            }
+
+            return regularBrush;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/Models/CellState.cs
+++ b/Models/CellState.cs
@@ -1,0 +1,10 @@
+namespace Caro_game.Models
+{
+    public class CellState
+    {
+        public int Row { get; set; }
+        public int Col { get; set; }
+        public string? Value { get; set; }
+        public bool IsWinningCell { get; set; }
+    }
+}

--- a/Models/GameEndedEventArgs.cs
+++ b/Models/GameEndedEventArgs.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Caro_game.Models
+{
+    public class GameEndedEventArgs : EventArgs
+    {
+        public GameEndedEventArgs(string winner, bool playAgain, bool hasWinner)
+        {
+            Winner = winner;
+            PlayAgain = playAgain;
+            HasWinner = hasWinner;
+        }
+
+        public string Winner { get; }
+        public bool PlayAgain { get; }
+        public bool HasWinner { get; }
+    }
+}

--- a/Models/GameState.cs
+++ b/Models/GameState.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace Caro_game.Models
+{
+    public class GameState
+    {
+        public int Rows { get; set; }
+        public int Columns { get; set; }
+        public string? FirstPlayer { get; set; }
+        public string? CurrentPlayer { get; set; }
+        public bool IsAIEnabled { get; set; }
+        public string? AIMode { get; set; }
+        public int TimeLimitMinutes { get; set; }
+        public int? RemainingSeconds { get; set; }
+        public bool IsPaused { get; set; }
+        public DateTime SavedAt { get; set; }
+        public List<CellState> Cells { get; set; } = new();
+    }
+}

--- a/Models/TimeOption.cs
+++ b/Models/TimeOption.cs
@@ -1,0 +1,16 @@
+namespace Caro_game.Models
+{
+    public class TimeOption
+    {
+        public TimeOption(int minutes, string display)
+        {
+            Minutes = minutes;
+            Display = display;
+        }
+
+        public int Minutes { get; }
+        public string Display { get; }
+
+        public override string ToString() => Display;
+    }
+}

--- a/Resources/Themes/DarkTheme.xaml
+++ b/Resources/Themes/DarkTheme.xaml
@@ -1,0 +1,16 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Color x:Key="PrimaryColor">#3B82F6</Color>
+    <SolidColorBrush x:Key="Primary" Color="{StaticResource PrimaryColor}"/>
+
+    <SolidColorBrush x:Key="DefaultForeground" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="#0F172A"/>
+    <SolidColorBrush x:Key="SurfaceBackgroundBrush" Color="#111827"/>
+    <SolidColorBrush x:Key="SectionBackgroundBrush" Color="#0B1220"/>
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#1E293B"/>
+    <SolidColorBrush x:Key="CellBackgroundBrush" Color="#1F2937"/>
+    <SolidColorBrush x:Key="CellBorderBrush" Color="#1F2937"/>
+    <SolidColorBrush x:Key="AccentForegroundBrush" Color="#C7D2FE"/>
+    <SolidColorBrush x:Key="MutedForegroundBrush" Color="#9CA3AF"/>
+    <SolidColorBrush x:Key="WinningCellBrush" Color="#FACC15"/>
+</ResourceDictionary>

--- a/Resources/Themes/LightTheme.xaml
+++ b/Resources/Themes/LightTheme.xaml
@@ -1,0 +1,16 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Color x:Key="PrimaryColor">#2563EB</Color>
+    <SolidColorBrush x:Key="Primary" Color="{StaticResource PrimaryColor}"/>
+
+    <SolidColorBrush x:Key="DefaultForeground" Color="#111827"/>
+    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="#F3F4F6"/>
+    <SolidColorBrush x:Key="SurfaceBackgroundBrush" Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="SectionBackgroundBrush" Color="#E5E7EB"/>
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="CellBackgroundBrush" Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="CellBorderBrush" Color="#CBD5F5"/>
+    <SolidColorBrush x:Key="AccentForegroundBrush" Color="#1E3A8A"/>
+    <SolidColorBrush x:Key="MutedForegroundBrush" Color="#4B5563"/>
+    <SolidColorBrush x:Key="WinningCellBrush" Color="#F59E0B"/>
+</ResourceDictionary>

--- a/ViewModels/BoardViewModel.cs
+++ b/ViewModels/BoardViewModel.cs
@@ -1,6 +1,7 @@
-﻿using Caro_game.Commands;
+using Caro_game.Commands;
 using Caro_game.Models;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,66 +11,125 @@ namespace Caro_game.ViewModels
 {
     public class BoardViewModel : BaseViewModel
     {
-        public int Rows { get; set; }
-        public int Columns { get; set; }
-        public ObservableCollection<Cell> Cells { get; set; }
+        public int Rows { get; }
+        public int Columns { get; }
+        public ObservableCollection<Cell> Cells { get; }
+
+        private readonly Dictionary<(int Row, int Col), Cell> _cellLookup;
+        private readonly HashSet<(int Row, int Col)> _candidatePositions;
+        private readonly object _candidateLock = new();
+        private readonly string _initialPlayer;
 
         private string _currentPlayer;
         public string CurrentPlayer
         {
             get => _currentPlayer;
-            set { _currentPlayer = value; OnPropertyChanged(); }
+            set
+            {
+                if (_currentPlayer != value)
+                {
+                    _currentPlayer = value;
+                    OnPropertyChanged();
+                }
+            }
         }
 
         private bool _isAIEnabled;
         public bool IsAIEnabled
         {
             get => _isAIEnabled;
-            set { _isAIEnabled = value; OnPropertyChanged(); }
+            set
+            {
+                if (_isAIEnabled != value)
+                {
+                    _isAIEnabled = value;
+                    OnPropertyChanged();
+                }
+            }
         }
 
-        private string _aiMode;
+        private string _aiMode = "Dễ";
         public string AIMode
         {
             get => _aiMode;
-            set { _aiMode = value; OnPropertyChanged(); }
+            set
+            {
+                if (_aiMode != value)
+                {
+                    _aiMode = value;
+                    OnPropertyChanged();
+                }
+            }
         }
+
+        private bool _isPaused;
+        public bool IsPaused
+        {
+            get => _isPaused;
+            set
+            {
+                if (_isPaused != value)
+                {
+                    _isPaused = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string InitialPlayer => _initialPlayer;
+
+        public event EventHandler<GameEndedEventArgs>? GameEnded;
 
         public BoardViewModel(int rows, int columns, string firstPlayer)
         {
             Rows = rows;
             Columns = columns;
-            CurrentPlayer = firstPlayer.StartsWith("X") ? "X" : "O";
+            CurrentPlayer = firstPlayer.StartsWith("X", StringComparison.OrdinalIgnoreCase) ? "X" : "O";
 
+            _initialPlayer = CurrentPlayer;
             Cells = new ObservableCollection<Cell>();
+            _cellLookup = new Dictionary<(int, int), Cell>(rows * columns);
+            _candidatePositions = new HashSet<(int, int)>();
 
             for (int i = 0; i < rows * columns; i++)
             {
                 int r = i / columns;
                 int c = i % columns;
-                var cell = new Cell(r, c, this);
-                cell.ClickCommand = new RelayCommand(_ => MakeMove(cell));
+                var cell = new Cell(r, c, this)
+                {
+                    ClickCommand = new RelayCommand(_ => MakeMove(cell))
+                };
                 Cells.Add(cell);
+                _cellLookup[(r, c)] = cell;
             }
         }
 
         public void MakeMove(Cell cell)
         {
-            if (!string.IsNullOrEmpty(cell.Value)) return;
+            if (IsPaused || !string.IsNullOrEmpty(cell.Value))
+            {
+                return;
+            }
 
             cell.Value = CurrentPlayer;
+            UpdateCandidatePositions(cell.Row, cell.Col);
 
             if (CheckWin(cell.Row, cell.Col, CurrentPlayer))
             {
                 HighlightWinningCells(cell.Row, cell.Col, CurrentPlayer);
 
-                App.Current.Dispatcher.Invoke(() =>
+                Application.Current.Dispatcher.Invoke(() =>
                 {
-                    var dialog = new Caro_game.Views.WinDialog($"Người chơi {CurrentPlayer} thắng!");
-                    dialog.Owner = Application.Current.MainWindow;
-                    bool? result = dialog.ShowDialog();
+                    var dialog = new Views.WinDialog($"Người chơi {CurrentPlayer} thắng!")
+                    {
+                        Owner = Application.Current.MainWindow
+                    };
 
-                    if (result == true && dialog.IsPlayAgain)
+                    dialog.ShowDialog();
+
+                    GameEnded?.Invoke(this, new GameEndedEventArgs(CurrentPlayer, dialog.IsPlayAgain, true));
+
+                    if (dialog.IsPlayAgain)
                     {
                         ResetBoard();
                     }
@@ -78,101 +138,147 @@ namespace Caro_game.ViewModels
                         Application.Current.Shutdown();
                     }
                 });
+
                 return;
             }
 
-            CurrentPlayer = (CurrentPlayer == "X") ? "O" : "X";
+            CurrentPlayer = CurrentPlayer == "X" ? "O" : "X";
 
             if (IsAIEnabled && CurrentPlayer == "O")
             {
-                Task.Run(() => AIMove());
+                Task.Run(AIMove);
             }
         }
 
         private void AIMove()
         {
-            if (!IsAIEnabled) return;
+            if (!IsAIEnabled || IsPaused)
+            {
+                return;
+            }
 
-            Cell bestCell = null;
+            Cell? bestCell = null;
 
             if (AIMode == "Dễ")
             {
-                
                 var lastPlayerMove = Cells.LastOrDefault(c => c.Value == "X");
                 if (lastPlayerMove != null)
                 {
-                    
-                    var neighbors = Cells.Where(c =>
-                        string.IsNullOrEmpty(c.Value) &&
-                        Math.Abs(c.Row - lastPlayerMove.Row) <= 1 &&
-                        Math.Abs(c.Col - lastPlayerMove.Col) <= 1).ToList();
+                    var neighbors = GetNeighbors(lastPlayerMove.Row, lastPlayerMove.Col, 1)
+                        .Where(c => string.IsNullOrEmpty(c.Value))
+                        .ToList();
 
                     if (neighbors.Any())
                     {
-                        bestCell = neighbors[new Random().Next(neighbors.Count)];
+                        bestCell = neighbors[Random.Shared.Next(neighbors.Count)];
                     }
                 }
 
-                
                 if (bestCell == null)
                 {
                     var emptyCells = Cells.Where(c => string.IsNullOrEmpty(c.Value)).ToList();
                     if (emptyCells.Any())
-                        bestCell = emptyCells[new Random().Next(emptyCells.Count)];
+                    {
+                        bestCell = emptyCells[Random.Shared.Next(emptyCells.Count)];
+                    }
                 }
             }
             else
             {
-                var candidates = Cells
-                    .Where(c => string.IsNullOrEmpty(c.Value) && HasNeighbor(c, 2))
-                    .ToList();
+                List<Cell> candidateCells;
+                lock (_candidateLock)
+                {
+                    candidateCells = _candidatePositions
+                        .Select(pos => _cellLookup[pos])
+                        .Where(c => string.IsNullOrEmpty(c.Value))
+                        .ToList();
+                }
 
-                if (!candidates.Any())
-                    candidates = Cells.Where(c => string.IsNullOrEmpty(c.Value)).ToList();
+                if (!candidateCells.Any())
+                {
+                    candidateCells = Cells
+                        .Where(c => string.IsNullOrEmpty(c.Value) && HasNeighbor(c, 1))
+                        .ToList();
+                }
+
+                if (!candidateCells.Any())
+                {
+                    if (_cellLookup.TryGetValue((Rows / 2, Columns / 2), out var center) && string.IsNullOrEmpty(center.Value))
+                    {
+                        candidateCells.Add(center);
+                    }
+                }
+
+                if (!candidateCells.Any())
+                {
+                    candidateCells = Cells.Where(c => string.IsNullOrEmpty(c.Value)).ToList();
+                }
 
                 int bestScore = int.MinValue;
 
-                foreach (var cell in candidates)
+                foreach (var candidate in candidateCells)
                 {
-                    int score = EvaluateCellAdvanced(cell);
+                    int score = EvaluateCellAdvanced(candidate);
                     if (score > bestScore)
                     {
                         bestScore = score;
-                        bestCell = cell;
+                        bestCell = candidate;
                     }
                 }
             }
 
             if (bestCell != null)
             {
-                App.Current.Dispatcher.Invoke(() => MakeMove(bestCell));
+                Application.Current.Dispatcher.Invoke(() => MakeMove(bestCell));
             }
         }
 
-        private bool HasNeighbor(Cell cell, int range)
+        private IEnumerable<Cell> GetNeighbors(int row, int col, int range)
         {
             for (int dr = -range; dr <= range; dr++)
             {
                 for (int dc = -range; dc <= range; dc++)
                 {
-                    if (dr == 0 && dc == 0) continue;
+                    if (dr == 0 && dc == 0)
+                    {
+                        continue;
+                    }
 
-                    int r = cell.Row + dr;
-                    int c = cell.Col + dc;
+                    int r = row + dr;
+                    int c = col + dc;
 
-                    var neighbor = Cells.FirstOrDefault(x => x.Row == r && x.Col == c);
-                    if (neighbor != null && !string.IsNullOrEmpty(neighbor.Value))
-                        return true;
+                    if (_cellLookup.TryGetValue((r, c), out var neighbor))
+                    {
+                        yield return neighbor;
+                    }
                 }
             }
-            return false;
         }
+
+        private void UpdateCandidatePositions(int row, int col)
+        {
+            lock (_candidateLock)
+            {
+                _candidatePositions.Remove((row, col));
+
+                foreach (var neighbor in GetNeighbors(row, col, 2))
+                {
+                    if (string.IsNullOrEmpty(neighbor.Value))
+                    {
+                        _candidatePositions.Add((neighbor.Row, neighbor.Col));
+                    }
+                }
+            }
+        }
+
+        private bool HasNeighbor(Cell cell, int range)
+            => GetNeighbors(cell.Row, cell.Col, range).Any(n => !string.IsNullOrEmpty(n.Value));
 
         private int EvaluateCellAdvanced(Cell cell)
         {
             int score = 0;
 
-            score += EvaluatePotential(cell, "O") * 1;
+            score += EvaluatePotential(cell, "O");
             score += EvaluatePotential(cell, "X") * 2;
             score += ProximityScore(cell, "X") * 5;
 
@@ -182,19 +288,15 @@ namespace Caro_game.ViewModels
         private int ProximityScore(Cell cell, string player)
         {
             int score = 0;
-            int[][] dirs = {
-                new[] {0,1}, new[] {1,0}, new[] {1,1}, new[] {1,-1},
-                new[] {-1,0}, new[] {0,-1}, new[] {-1,-1}, new[] {-1,1}
-            };
 
-            foreach (var dir in dirs)
+            foreach (var neighbor in GetNeighbors(cell.Row, cell.Col, 1))
             {
-                int r = cell.Row + dir[0];
-                int c = cell.Col + dir[1];
-                var neighbor = Cells.FirstOrDefault(x => x.Row == r && x.Col == c);
-                if (neighbor != null && neighbor.Value == player)
+                if (neighbor.Value == player)
+                {
                     score += 1;
+                }
             }
+
             return score;
         }
 
@@ -209,14 +311,16 @@ namespace Caro_game.ViewModels
                 count += CountDirectionSimulate(cell.Row, cell.Col, dir[0], dir[1], player);
                 count += CountDirectionSimulate(cell.Row, cell.Col, -dir[0], -dir[1], player);
 
-                switch (count)
+                totalScore += count switch
                 {
-                    case 5: totalScore += 10000; break;
-                    case 4: totalScore += 1000; break;
-                    case 3: totalScore += 100; break;
-                    case 2: totalScore += 10; break;
-                }
+                    >= 5 => 10000,
+                    4 => 1000,
+                    3 => 100,
+                    2 => 10,
+                    _ => 0
+                };
             }
+
             return totalScore;
         }
 
@@ -228,15 +332,18 @@ namespace Caro_game.ViewModels
 
             while (r >= 0 && r < Rows && c >= 0 && c < Columns)
             {
-                var neighbor = Cells.FirstOrDefault(x => x.Row == r && x.Col == c);
-                if (neighbor != null && neighbor.Value == player)
+                if (_cellLookup.TryGetValue((r, c), out var neighbor) && neighbor.Value == player)
                 {
                     count++;
                     r += dRow;
                     c += dCol;
                 }
-                else break;
+                else
+                {
+                    break;
+                }
             }
+
             return count;
         }
 
@@ -250,8 +357,12 @@ namespace Caro_game.ViewModels
                 count += CountDirectionSimulate(row, col, dir[0], dir[1], player);
                 count += CountDirectionSimulate(row, col, -dir[0], -dir[1], player);
 
-                if (count >= 5) return true;
+                if (count >= 5)
+                {
+                    return true;
+                }
             }
+
             return false;
         }
 
@@ -262,39 +373,45 @@ namespace Caro_game.ViewModels
             foreach (var dir in directions)
             {
                 var line = GetLine(row, col, dir[0], dir[1], player);
-                var oppositeLine = GetLine(row, col, -dir[0], -dir[1], player);
+                var opposite = GetLine(row, col, -dir[0], -dir[1], player);
+                line.AddRange(opposite);
 
-                foreach (var c in oppositeLine) line.Add(c);
-
-                var centerCell = Cells.First(c => c.Row == row && c.Col == col);
-                line.Add(centerCell);
+                if (_cellLookup.TryGetValue((row, col), out var center))
+                {
+                    line.Add(center);
+                }
 
                 if (line.Count >= 5)
                 {
                     foreach (var c in line)
+                    {
                         c.IsWinningCell = true;
+                    }
                     break;
                 }
             }
         }
 
-        private ObservableCollection<Cell> GetLine(int row, int col, int dRow, int dCol, string player)
+        private List<Cell> GetLine(int row, int col, int dRow, int dCol, string player)
         {
-            var list = new ObservableCollection<Cell>();
+            var list = new List<Cell>();
             int r = row + dRow;
             int c = col + dCol;
 
             while (r >= 0 && r < Rows && c >= 0 && c < Columns)
             {
-                var cell = Cells.FirstOrDefault(x => x.Row == r && x.Col == c);
-                if (cell != null && cell.Value == player)
+                if (_cellLookup.TryGetValue((r, c), out var cell) && cell.Value == player)
                 {
                     list.Add(cell);
                     r += dRow;
                     c += dCol;
                 }
-                else break;
+                else
+                {
+                    break;
+                }
             }
+
             return list;
         }
 
@@ -305,7 +422,19 @@ namespace Caro_game.ViewModels
                 cell.Value = string.Empty;
                 cell.IsWinningCell = false;
             }
-            CurrentPlayer = "X";
+
+            lock (_candidateLock)
+            {
+                _candidatePositions.Clear();
+            }
+
+            CurrentPlayer = _initialPlayer;
+            IsPaused = false;
+        }
+
+        public void PauseBoard()
+        {
+            IsPaused = true;
         }
     }
 }

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -1,161 +1,552 @@
-﻿using System.Collections.ObjectModel;
+using System;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Threading;
 using Caro_game.Commands;
+using Caro_game.Models;
+using Microsoft.Win32;
 
 namespace Caro_game.ViewModels
 {
     public class MainViewModel : INotifyPropertyChanged
     {
+        private const string DefaultDarkThemeLabel = "Dark (mặc định)";
+
+        private static readonly Uri DarkThemeUri = new("Resources/Themes/DarkTheme.xaml", UriKind.Relative);
+        private static readonly Uri LightThemeUri = new("Resources/Themes/LightTheme.xaml", UriKind.Relative);
+
         private string _firstPlayer;
-        private BoardViewModel _board;
+        private BoardViewModel? _board;
         private bool _isAIEnabled;
         private string _selectedAIMode;
+        private TimeOption _selectedTimeOption;
+        private string _selectedTheme;
+        private string _selectedPrimaryColor;
+        private bool _isSoundEnabled;
+        private bool _isGameActive;
+        private bool _isGamePaused;
+        private TimeSpan _remainingTime;
+        private string _statusMessage;
+        private DispatcherTimer? _gameTimer;
+        private TimeSpan _configuredDuration = TimeSpan.Zero;
 
         // Thuộc tính cho cấu hình bảng
-        public ObservableCollection<int> RowOptions { get; set; }
-        public ObservableCollection<int> ColumnOptions { get; set; }
-        public ObservableCollection<string> Players { get; set; }
-        public ObservableCollection<string> AIModes { get; set; }
+        public ObservableCollection<int> RowOptions { get; }
+        public ObservableCollection<int> ColumnOptions { get; }
+        public ObservableCollection<string> Players { get; }
+        public ObservableCollection<string> AIModes { get; }
+        public ObservableCollection<TimeOption> TimeOptions { get; }
 
         private int _selectedRows;
         public int SelectedRows
         {
             get => _selectedRows;
-            set { _selectedRows = value; OnPropertyChanged(); }
+            set
+            {
+                if (_selectedRows != value)
+                {
+                    _selectedRows = value;
+                    OnPropertyChanged();
+                }
+            }
         }
 
         private int _selectedColumns;
         public int SelectedColumns
         {
             get => _selectedColumns;
-            set { _selectedColumns = value; OnPropertyChanged(); }
+            set
+            {
+                if (_selectedColumns != value)
+                {
+                    _selectedColumns = value;
+                    OnPropertyChanged();
+                }
+            }
         }
 
         public string FirstPlayer
         {
             get => _firstPlayer;
-            set { _firstPlayer = value; OnPropertyChanged(); }
+            set
+            {
+                if (_firstPlayer != value)
+                {
+                    _firstPlayer = value;
+                    OnPropertyChanged();
+                }
+            }
         }
 
-        public BoardViewModel Board
+        public BoardViewModel? Board
         {
             get => _board;
-            set { _board = value; OnPropertyChanged(); }
+            private set
+            {
+                if (_board != null)
+                {
+                    _board.GameEnded -= OnBoardGameEnded;
+                }
+
+                _board = value;
+
+                if (_board != null)
+                {
+                    _board.GameEnded += OnBoardGameEnded;
+                }
+
+                OnPropertyChanged();
+                CommandManager.InvalidateRequerySuggested();
+            }
         }
 
         public bool IsAIEnabled
         {
             get => _isAIEnabled;
-            set { _isAIEnabled = value; OnPropertyChanged(); }
+            set
+            {
+                if (_isAIEnabled != value)
+                {
+                    _isAIEnabled = value;
+                    OnPropertyChanged();
+                }
+            }
         }
 
         public string SelectedAIMode
         {
             get => _selectedAIMode;
-            set { _selectedAIMode = value; OnPropertyChanged(); }
+            set
+            {
+                if (_selectedAIMode != value)
+                {
+                    _selectedAIMode = value;
+                    OnPropertyChanged();
+                }
+            }
         }
 
         // --- Cài đặt giao diện ---
-        public ObservableCollection<string> Themes { get; set; } =
-            new ObservableCollection<string> { "Dark (mặc định)", "Light" };
+        public ObservableCollection<string> Themes { get; } =
+            new ObservableCollection<string> { DefaultDarkThemeLabel, "Light" };
 
-        public ObservableCollection<string> PrimaryColors { get; set; } =
+        public ObservableCollection<string> PrimaryColors { get; } =
             new ObservableCollection<string> { "Xanh dương", "Tím", "Lục" };
 
-        private string _selectedTheme;
         public string SelectedTheme
         {
             get => _selectedTheme;
-            set { _selectedTheme = value; OnPropertyChanged(); }
+            set
+            {
+                if (_selectedTheme != value)
+                {
+                    _selectedTheme = value;
+                    OnPropertyChanged();
+                }
+            }
         }
 
-        private string _selectedPrimaryColor;
         public string SelectedPrimaryColor
         {
             get => _selectedPrimaryColor;
-            set { _selectedPrimaryColor = value; OnPropertyChanged(); }
+            set
+            {
+                if (_selectedPrimaryColor != value)
+                {
+                    _selectedPrimaryColor = value;
+                    OnPropertyChanged();
+                }
+            }
         }
 
-        private bool _isSoundEnabled;
         public bool IsSoundEnabled
         {
             get => _isSoundEnabled;
-            set { _isSoundEnabled = value; OnPropertyChanged(); }
+            set
+            {
+                if (_isSoundEnabled != value)
+                {
+                    _isSoundEnabled = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public TimeOption SelectedTimeOption
+        {
+            get => _selectedTimeOption;
+            set
+            {
+                if (value != null && _selectedTimeOption.Minutes != value.Minutes)
+                {
+                    _selectedTimeOption = value;
+                    OnPropertyChanged();
+                    if (!IsGameActive)
+                    {
+                        RemainingTime = value.Minutes > 0
+                            ? TimeSpan.FromMinutes(value.Minutes)
+                            : TimeSpan.Zero;
+                    }
+                    OnPropertyChanged(nameof(RemainingTimeDisplay));
+                }
+            }
+        }
+
+        public TimeSpan RemainingTime
+        {
+            get => _remainingTime;
+            private set
+            {
+                if (_remainingTime != value)
+                {
+                    _remainingTime = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(RemainingTimeDisplay));
+                }
+            }
+        }
+
+        public string RemainingTimeDisplay =>
+            SelectedTimeOption.Minutes > 0
+                ? RemainingTime.ToString(@"mm\:ss")
+                : "Không giới hạn";
+
+        public bool IsGameActive
+        {
+            get => _isGameActive;
+            private set
+            {
+                if (_isGameActive != value)
+                {
+                    _isGameActive = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(PauseButtonText));
+                    CommandManager.InvalidateRequerySuggested();
+                }
+            }
+        }
+
+        public bool IsGamePaused
+        {
+            get => _isGamePaused;
+            private set
+            {
+                if (_isGamePaused != value)
+                {
+                    _isGamePaused = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(PauseButtonText));
+                }
+            }
+        }
+
+        public string PauseButtonText => IsGamePaused ? "Tiếp tục" : "Tạm dừng";
+
+        public string StatusMessage
+        {
+            get => _statusMessage;
+            private set
+            {
+                if (_statusMessage != value)
+                {
+                    _statusMessage = value;
+                    OnPropertyChanged();
+                }
+            }
         }
 
         // Commands
-        public ICommand StartGameCommand { get; set; }
-        public ICommand ExitCommand { get; set; }
-        public ICommand SaveSettingsCommand { get; set; }
+        public ICommand StartGameCommand { get; }
+        public ICommand TogglePauseCommand { get; }
+        public ICommand SaveGameCommand { get; }
+        public ICommand SaveSettingsCommand { get; }
 
         public MainViewModel()
         {
-            // Options cho bàn cờ
-            RowOptions = new ObservableCollection<int> { 15, 20 };
-            ColumnOptions = new ObservableCollection<int> { 18, 35 };
+            RowOptions = new ObservableCollection<int> { 15, 20, 25, 30, 40, 50, 75, 100 };
+            ColumnOptions = new ObservableCollection<int> { 18, 25, 30, 35, 40, 50, 75, 100 };
             Players = new ObservableCollection<string> { "X (Bạn)", "O" };
             AIModes = new ObservableCollection<string> { "Dễ", "Khó" };
+            TimeOptions = new ObservableCollection<TimeOption>
+            {
+                new TimeOption(0, "Không giới hạn"),
+                new TimeOption(5, "5 phút"),
+                new TimeOption(10, "10 phút"),
+                new TimeOption(15, "15 phút"),
+                new TimeOption(20, "20 phút"),
+                new TimeOption(30, "30 phút"),
+                new TimeOption(45, "45 phút"),
+                new TimeOption(60, "60 phút")
+            };
 
-            // Default
             SelectedRows = 20;
             SelectedColumns = 35;
             FirstPlayer = "X (Bạn)";
             IsAIEnabled = true;
             SelectedAIMode = "Khó";
 
-            SelectedTheme = "Dark (mặc định)";
+            SelectedTheme = DefaultDarkThemeLabel;
             SelectedPrimaryColor = "Xanh dương";
             IsSoundEnabled = true;
+            _selectedTimeOption = TimeOptions[3]; // 15 phút mặc định
+            RemainingTime = TimeSpan.FromMinutes(_selectedTimeOption.Minutes);
+            StatusMessage = "Chưa bắt đầu";
 
-            // Commands
             StartGameCommand = new RelayCommand(StartGame);
-            ExitCommand = new RelayCommand(_ => Application.Current.Shutdown());
+            TogglePauseCommand = new RelayCommand(_ => TogglePause(), _ => Board != null && IsGameActive);
+            SaveGameCommand = new RelayCommand(_ => SaveCurrentGame(), _ => Board != null);
             SaveSettingsCommand = new RelayCommand(_ => SaveSettings());
         }
 
-        private void StartGame(object parameter)
+        private void StartGame(object? parameter)
         {
             int rows = SelectedRows;
             int cols = SelectedColumns;
 
-            Board = new BoardViewModel(rows, cols, FirstPlayer)
+            var board = new BoardViewModel(rows, cols, FirstPlayer)
             {
-                IsAIEnabled = this.IsAIEnabled,
-                AIMode = this.SelectedAIMode
+                IsAIEnabled = IsAIEnabled,
+                AIMode = SelectedAIMode
             };
+
+            Board = board;
+
+            _configuredDuration = SelectedTimeOption.Minutes > 0
+                ? TimeSpan.FromMinutes(SelectedTimeOption.Minutes)
+                : TimeSpan.Zero;
+
+            StartTimer();
+
+            IsGameActive = true;
+            IsGamePaused = false;
+            board.IsPaused = false;
+            StatusMessage = "Đang chơi";
+        }
+
+        private void TogglePause()
+        {
+            if (Board == null)
+            {
+                return;
+            }
+
+            if (!IsGamePaused)
+            {
+                IsGamePaused = true;
+                Board.IsPaused = true;
+                _gameTimer?.Stop();
+                StatusMessage = "Đang tạm dừng";
+            }
+            else
+            {
+                if (SelectedTimeOption.Minutes > 0 && RemainingTime <= TimeSpan.Zero)
+                {
+                    return;
+                }
+
+                IsGamePaused = false;
+                Board.IsPaused = false;
+                if (_configuredDuration > TimeSpan.Zero)
+                {
+                    _gameTimer?.Start();
+                }
+                StatusMessage = "Đang chơi";
+            }
+        }
+
+        private void StartTimer()
+        {
+            StopTimer();
+
+            if (_configuredDuration > TimeSpan.Zero)
+            {
+                RemainingTime = _configuredDuration;
+                _gameTimer = new DispatcherTimer
+                {
+                    Interval = TimeSpan.FromSeconds(1)
+                };
+                _gameTimer.Tick += OnGameTimerTick;
+                _gameTimer.Start();
+            }
+            else
+            {
+                RemainingTime = TimeSpan.Zero;
+            }
+        }
+
+        private void StopTimer()
+        {
+            if (_gameTimer != null)
+            {
+                _gameTimer.Stop();
+                _gameTimer.Tick -= OnGameTimerTick;
+                _gameTimer = null;
+            }
+        }
+
+        private void OnGameTimerTick(object? sender, EventArgs e)
+        {
+            if (IsGamePaused)
+            {
+                return;
+            }
+
+            if (RemainingTime > TimeSpan.Zero)
+            {
+                RemainingTime -= TimeSpan.FromSeconds(1);
+            }
+
+            if (RemainingTime <= TimeSpan.Zero)
+            {
+                RemainingTime = TimeSpan.Zero;
+                StopTimer();
+                HandleTimeExpired();
+            }
+        }
+
+        private void HandleTimeExpired()
+        {
+            Board?.PauseBoard();
+            IsGameActive = false;
+            IsGamePaused = false;
+            StatusMessage = "Hết thời gian";
+            MessageBox.Show("Hết thời gian! Ván đấu đã kết thúc.", "Thông báo", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        private void SaveCurrentGame()
+        {
+            if (Board == null)
+            {
+                return;
+            }
+
+            var dialog = new SaveFileDialog
+            {
+                Filter = "Caro Save|*.json",
+                FileName = $"caro_{DateTime.Now:yyyyMMdd_HHmmss}.json"
+            };
+
+            if (dialog.ShowDialog() == true)
+            {
+                var state = new GameState
+                {
+                    Rows = Board.Rows,
+                    Columns = Board.Columns,
+                    FirstPlayer = Board.InitialPlayer,
+                    CurrentPlayer = Board.CurrentPlayer,
+                    IsAIEnabled = Board.IsAIEnabled,
+                    AIMode = Board.AIMode,
+                    TimeLimitMinutes = SelectedTimeOption.Minutes,
+                    RemainingSeconds = SelectedTimeOption.Minutes > 0 ? (int?)Math.Ceiling(RemainingTime.TotalSeconds) : null,
+                    IsPaused = IsGamePaused,
+                    SavedAt = DateTime.Now,
+                    Cells = Board.Cells.Select(c => new CellState
+                    {
+                        Row = c.Row,
+                        Col = c.Col,
+                        Value = c.Value,
+                        IsWinningCell = c.IsWinningCell
+                    }).ToList()
+                };
+
+                var json = JsonSerializer.Serialize(state, new JsonSerializerOptions
+                {
+                    WriteIndented = true
+                });
+
+                File.WriteAllText(dialog.FileName, json);
+                MessageBox.Show("Ván đấu đã được lưu!", "Thông báo", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
         }
 
         private void SaveSettings()
         {
-            // Theme
-            if (SelectedTheme == "Light")
-            {
-                Application.Current.MainWindow.Background = new SolidColorBrush(Colors.WhiteSmoke);
-                Application.Current.Resources["DefaultForeground"] = new SolidColorBrush(Colors.Black);
-            }
-            else // Dark
-            {
-                Application.Current.MainWindow.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#0F172A"));
-                Application.Current.Resources["DefaultForeground"] = new SolidColorBrush(Colors.White);
-            }
-
-            // Primary color
-            Color primaryColor = Colors.DeepSkyBlue;
-            if (SelectedPrimaryColor == "Tím") primaryColor = Colors.MediumPurple;
-            else if (SelectedPrimaryColor == "Lục") primaryColor = Colors.MediumSeaGreen;
-
-            Application.Current.Resources["Primary"] = new SolidColorBrush(primaryColor);
-
-            // Thông báo
+            ApplyTheme();
+            ApplyPrimaryColor();
             MessageBox.Show("Cài đặt đã được áp dụng!", "Thông báo", MessageBoxButton.OK, MessageBoxImage.Information);
         }
 
-        public event PropertyChangedEventHandler PropertyChanged;
-        protected void OnPropertyChanged([CallerMemberName] string name = null)
+        private void ApplyTheme()
+        {
+            var themeUri = SelectedTheme == "Light" ? LightThemeUri : DarkThemeUri;
+            var dictionaries = Application.Current.Resources.MergedDictionaries;
+            ResourceDictionary? currentTheme = null;
+
+            foreach (var dictionary in dictionaries)
+            {
+                if (dictionary.Source != null && dictionary.Source.OriginalString.Contains("Resources/Themes"))
+                {
+                    currentTheme = dictionary;
+                    break;
+                }
+            }
+
+            if (currentTheme != null && currentTheme.Source == themeUri)
+            {
+                return;
+            }
+
+            if (currentTheme != null)
+            {
+                dictionaries.Remove(currentTheme);
+            }
+
+            dictionaries.Add(new ResourceDictionary { Source = themeUri });
+        }
+
+        private void ApplyPrimaryColor()
+        {
+            Color primaryColor = Colors.DeepSkyBlue;
+            if (SelectedPrimaryColor == "Tím")
+            {
+                primaryColor = Colors.MediumPurple;
+            }
+            else if (SelectedPrimaryColor == "Lục")
+            {
+                primaryColor = Colors.MediumSeaGreen;
+            }
+
+            Application.Current.Resources["Primary"] = new SolidColorBrush(primaryColor);
+        }
+
+        private void OnBoardGameEnded(object? sender, GameEndedEventArgs e)
+        {
+            StopTimer();
+
+            if (e.HasWinner)
+            {
+                StatusMessage = $"Người chơi {e.Winner} thắng!";
+            }
+
+            if (e.PlayAgain)
+            {
+                IsGameActive = true;
+                IsGamePaused = false;
+                Board!.IsPaused = false;
+                StartTimer();
+                StatusMessage = "Đang chơi";
+            }
+            else
+            {
+                IsGameActive = false;
+                IsGamePaused = false;
+                if (_configuredDuration > TimeSpan.Zero)
+                {
+                    RemainingTime = _configuredDuration;
+                }
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected void OnPropertyChanged([CallerMemberName] string? name = null)
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
     }
 }

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="Caro_game.Views.MainWindow"
+<Window x:Class="Caro_game.Views.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -9,13 +9,11 @@
         Title="Caro Game"
         Width="1000" Height="700"
         WindowStartupLocation="CenterScreen"
-        Background="#0F172A"
+        Background="{DynamicResource WindowBackgroundBrush}"
         WindowState="Maximized">
 
     <Window.Resources>
         <conv:BoolToBrushConverter x:Key="BoolToBrushConverter"/>
-        <SolidColorBrush x:Key="Primary" Color="#2D7EF7"/>
-        <SolidColorBrush x:Key="DefaultForeground" Color="White"/>
     </Window.Resources>
 
     <Window.DataContext>
@@ -23,12 +21,12 @@
     </Window.DataContext>
 
     <Grid Margin="20">
-        <Border Background="#111827" CornerRadius="12" Padding="16">
+        <Border Background="{DynamicResource SurfaceBackgroundBrush}" CornerRadius="12" Padding="16">
             <TabControl>
 
                 <!-- Chơi -->
                 <TabItem Header="▶  Chơi">
-                    <Border Background="#0B1220" Margin="-4" Padding="16">
+                    <Border Background="{DynamicResource SectionBackgroundBrush}" Margin="-4" Padding="16">
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="280"/>
@@ -36,7 +34,7 @@
                             </Grid.ColumnDefinitions>
 
                             <!-- Cột trái: tùy chọn -->
-                            <Border Grid.Column="0" Background="#1E293B" CornerRadius="12" Padding="16">
+                            <Border Grid.Column="0" Background="{DynamicResource CardBackgroundBrush}" CornerRadius="12" Padding="16">
                                 <StackPanel>
                                     <TextBlock Text="Tùy chọn nhanh" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource DefaultForeground}"/>
                                     <Separator Margin="0,8"/>
@@ -59,7 +57,6 @@
                                     <CheckBox Content="Chơi với máy" Margin="0,10,0,0"
                                               IsChecked="{Binding IsAIEnabled}" Foreground="{DynamicResource DefaultForeground}"/>
 
-                                    <!-- Thêm chọn chế độ AI -->
                                     <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                                         <TextBlock Text="Chế độ:" Width="120" Foreground="{DynamicResource DefaultForeground}"/>
                                         <ComboBox Width="120"
@@ -67,20 +64,67 @@
                                                   SelectedItem="{Binding SelectedAIMode}"/>
                                     </StackPanel>
 
+                                    <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                                        <TextBlock Text="Thời gian (phút):" Width="120" Foreground="{DynamicResource DefaultForeground}"/>
+                                        <ComboBox Width="120"
+                                                  ItemsSource="{Binding TimeOptions}"
+                                                  SelectedItem="{Binding SelectedTimeOption}"
+                                                  DisplayMemberPath="Display"/>
+                                    </StackPanel>
+
+                                    <TextBlock Text="{Binding RemainingTimeDisplay, StringFormat=Thời gian còn lại: {0}}"
+                                               Margin="0,6,0,0"
+                                               Foreground="{DynamicResource MutedForegroundBrush}"/>
+
+                                    <TextBlock Text="{Binding StatusMessage}"
+                                               Margin="0,10,0,0"
+                                               FontWeight="Bold"
+                                               Foreground="{DynamicResource AccentForegroundBrush}"/>
+
                                     <CheckBox Content="Bật âm thanh" Margin="0,10,0,0" IsChecked="True" Foreground="{DynamicResource DefaultForeground}"/>
 
-                                    <Button Content="Bắt đầu ván mới" Margin="0,16,0,0"
+                                    <StackPanel Orientation="Horizontal" Margin="0,16,0,0">
+                                        <Button Content="Bắt đầu ván mới"
+                                                Width="130"
+                                                Background="{StaticResource Primary}" Foreground="{DynamicResource DefaultForeground}"
+                                                Command="{Binding StartGameCommand}"/>
+                                        <Button Content="{Binding PauseButtonText}"
+                                                Width="110"
+                                                Margin="10,0,0,0"
+                                                Background="{StaticResource Primary}" Foreground="{DynamicResource DefaultForeground}"
+                                                Command="{Binding TogglePauseCommand}"/>
+                                    </StackPanel>
+
+                                    <Button Content="Lưu ván đấu"
+                                            Margin="0,10,0,0"
                                             Background="{StaticResource Primary}" Foreground="{DynamicResource DefaultForeground}"
-                                            Command="{Binding StartGameCommand}"/>
+                                            Command="{Binding SaveGameCommand}"/>
                                 </StackPanel>
                             </Border>
 
                             <!-- Cột phải: bàn cờ -->
-                            <Border Grid.Column="1" Background="#111827" CornerRadius="12" Padding="16">
+                            <Border Grid.Column="1" Background="{DynamicResource SurfaceBackgroundBrush}" CornerRadius="12" Padding="16">
                                 <StackPanel>
-                                    <TextBlock Text="{Binding Board.CurrentPlayer, StringFormat=Lượt hiện tại: {0}}"
-                                               FontSize="16" FontWeight="Bold"
-                                               Foreground="#C7D2FE" Margin="0,0,0,12"/>
+                                    <Grid Margin="0,0,0,12">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="{Binding Board.CurrentPlayer, StringFormat=Lượt hiện tại: {0}}"
+                                                   FontSize="16" FontWeight="Bold"
+                                                   Foreground="{DynamicResource AccentForegroundBrush}"/>
+                                        <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                            <TextBlock Text="Thời gian còn lại: "
+                                                       Foreground="{DynamicResource DefaultForeground}"/>
+                                            <TextBlock Text="{Binding RemainingTimeDisplay}"
+                                                       FontWeight="Bold"
+                                                       Foreground="{DynamicResource AccentForegroundBrush}"/>
+                                        </StackPanel>
+                                    </Grid>
+
+                                    <TextBlock Text="{Binding StatusMessage}"
+                                               Margin="0,0,0,12"
+                                               Foreground="{DynamicResource DefaultForeground}"/>
 
                                     <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
                                         <ItemsControl ItemsSource="{Binding Board.Cells}">
@@ -100,7 +144,7 @@
                                                             FontSize="16"
                                                             Background="{Binding IsWinningCell, Converter={StaticResource BoolToBrushConverter}}"
                                                             Foreground="{DynamicResource DefaultForeground}"
-                                                            BorderBrush="#1F2937"
+                                                            BorderBrush="{DynamicResource CellBorderBrush}"
                                                             BorderThickness="1"/>
                                                 </DataTemplate>
                                             </ItemsControl.ItemTemplate>
@@ -114,7 +158,7 @@
 
                 <!-- Hướng dẫn -->
                 <TabItem Header="📖  Hướng dẫn">
-                    <Border Background="#0B1220" Margin="-4" Padding="16">
+                    <Border Background="{DynamicResource SectionBackgroundBrush}" Margin="-4" Padding="16">
                         <ScrollViewer>
                             <StackPanel>
                                 <TextBlock Text="Luật chơi cơ bản" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource DefaultForeground}"/>
@@ -124,7 +168,7 @@
                                 <TextBlock Text="• Lượt đi: X và O thay phiên nhau." Margin="0,6,0,0" Foreground="{DynamicResource DefaultForeground}"/>
                                 <TextBlock Text="• Thắng: khi một bên có 5 quân liên tiếp." Margin="0,6,0,0" Foreground="{DynamicResource DefaultForeground}"/>
                                 <Separator Margin="0,8"/>
-                                <TextBlock Text="Mẹo nhanh" FontSize="16" FontWeight="Bold" Foreground="#C7D2FE" Margin="0,6,0,0"/>
+                                <TextBlock Text="Mẹo nhanh" FontSize="16" FontWeight="Bold" Foreground="{DynamicResource AccentForegroundBrush}" Margin="0,6,0,0"/>
                                 <TextBlock Text="• Ưu tiên trung tâm, mở rộng theo hai hướng." Foreground="{DynamicResource DefaultForeground}"/>
                                 <TextBlock Text="• Chặn nước 4 của đối thủ ngay." Foreground="{DynamicResource DefaultForeground}"/>
                                 <TextBlock Text="• Tạo thế 2 hướng mở để ép thắng." Foreground="{DynamicResource DefaultForeground}"/>
@@ -135,7 +179,7 @@
 
                 <!-- Cài đặt -->
                 <TabItem Header="⚙️  Cài đặt">
-                    <Border Background="#0B1220" Margin="-4" Padding="16">
+                    <Border Background="{DynamicResource SectionBackgroundBrush}" Margin="-4" Padding="16">
                         <StackPanel>
                             <TextBlock Text="Tùy chỉnh giao diện" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource DefaultForeground}"/>
                             <Separator Margin="0,8"/>


### PR DESCRIPTION
## Summary
- add resource dictionaries for dark and light themes and wire them into the settings workflow
- introduce configurable match timers, pause/resume controls, and live status messaging for ongoing games
- enable saving game state to JSON and optimize the AI/board logic to handle boards up to 100x100 efficiently

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d74753408322847d063ec5e40ac5