### PR TITLE
Improve small board layout scaling

### DIFF
--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -135,28 +135,33 @@
                                     <ScrollViewer Grid.Row="2"
                                                   HorizontalScrollBarVisibility="Auto"
                                                   VerticalScrollBarVisibility="Auto">
-                                        <ItemsControl ItemsSource="{Binding Board.Cells}">
-                                            <ItemsControl.ItemsPanel>
-                                                <ItemsPanelTemplate>
-                                                    <UniformGrid Rows="{Binding Board.Rows}" Columns="{Binding Board.Columns}"/>
-                                                </ItemsPanelTemplate>
-                                            </ItemsControl.ItemsPanel>
+                                        <Viewbox Stretch="Uniform"
+                                                 StretchDirection="UpOnly"
+                                                 HorizontalAlignment="Center"
+                                                 VerticalAlignment="Center">
+                                            <ItemsControl ItemsSource="{Binding Board.Cells}">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <UniformGrid Rows="{Binding Board.Rows}" Columns="{Binding Board.Columns}"/>
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
 
-                                            <ItemsControl.ItemTemplate>
-                                                <DataTemplate>
-                                                    <Button Content="{Binding Value}"
-                                                            Command="{Binding ClickCommand}"
-                                                            Width="30" Height="30"
-                                                            Margin="1"
-                                                            FontWeight="Bold"
-                                                            FontSize="16"
-                                                            Background="{Binding IsWinningCell, Converter={StaticResource BoolToBrushConverter}}"
-                                                            Foreground="{DynamicResource DefaultForeground}"
-                                                            BorderBrush="{DynamicResource CellBorderBrush}"
-                                                            BorderThickness="1"/>
-                                                </DataTemplate>
-                                            </ItemsControl.ItemTemplate>
-                                        </ItemsControl>
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Button Content="{Binding Value}"
+                                                                Command="{Binding ClickCommand}"
+                                                                Width="30" Height="30"
+                                                                Margin="1"
+                                                                FontWeight="Bold"
+                                                                FontSize="16"
+                                                                Background="{Binding IsWinningCell, Converter={StaticResource BoolToBrushConverter}}"
+                                                                Foreground="{DynamicResource DefaultForeground}"
+                                                                BorderBrush="{DynamicResource CellBorderBrush}"
+                                                                BorderThickness="1"/>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </Viewbox>
                                     </ScrollViewer>
                                 </Grid>
                             </Border>


### PR DESCRIPTION
## Summary
- wrap the board items control in a Viewbox so smaller boards scale up uniformly
- limit scaling to only enlarge content while keeping scroll support for larger boards

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da08df84808322885e8a25df3e4103