### PR TITLE
Add ability to load saved games

### DIFF
--- a/ViewModels/BoardViewModel.cs
+++ b/ViewModels/BoardViewModel.cs
@@ -219,6 +219,61 @@ namespace Caro_game.ViewModels
         }
 
 
+        public void LoadFromState(GameState state)
+        {
+            if (state.Rows != Rows || state.Columns != Columns)
+            {
+                throw new ArgumentException("Kích thước bàn không khớp với trạng thái đã lưu.");
+            }
+
+            foreach (var cell in Cells)
+            {
+                cell.Value = string.Empty;
+                cell.IsWinningCell = false;
+            }
+
+            if (state.Cells != null)
+            {
+                foreach (var cellState in state.Cells)
+                {
+                    if (_cellLookup.TryGetValue((cellState.Row, cellState.Col), out var cell))
+                    {
+                        cell.Value = cellState.Value ?? string.Empty;
+                        cell.IsWinningCell = cellState.IsWinningCell;
+                    }
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(state.CurrentPlayer))
+            {
+                CurrentPlayer = state.CurrentPlayer!;
+            }
+
+            RebuildCandidatePositions();
+
+            IsPaused = state.IsPaused;
+        }
+
+        private void RebuildCandidatePositions()
+        {
+            lock (_candidateLock)
+            {
+                _candidatePositions.Clear();
+
+                foreach (var filled in Cells.Where(c => !string.IsNullOrEmpty(c.Value)))
+                {
+                    foreach (var neighbor in GetNeighbors(filled.Row, filled.Col, 2))
+                    {
+                        if (string.IsNullOrEmpty(neighbor.Value))
+                        {
+                            _candidatePositions.Add((neighbor.Row, neighbor.Col));
+                        }
+                    }
+                }
+            }
+        }
+
+
         private void AIMove()
         {
             if (!IsAIEnabled || IsPaused)

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -99,6 +99,10 @@
                                             Margin="0,10,0,0"
                                             Background="{StaticResource Primary}" Foreground="{DynamicResource DefaultForeground}"
                                             Command="{Binding SaveGameCommand}"/>
+                                    <Button Content="Mở ván đã lưu"
+                                            Margin="0,10,0,0"
+                                            Background="{StaticResource Primary}" Foreground="{DynamicResource DefaultForeground}"
+                                            Command="{Binding LoadGameCommand}"/>
                                 </StackPanel>
                             </Border>
 


### PR DESCRIPTION
## Summary
- add a command and UI button to open previously saved games from the main screen
- restore board, timer, and settings state when loading a save file, including AI fallbacks when needed
- allow the board view model to rebuild its cells from serialized game data

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68da5360961c83228f7033a5667ddd2c