### PR TITLE
Add auto-expanding board for easy and hard levels

### DIFF
--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -39,16 +39,6 @@
                                     <TextBlock Text="Tùy chọn nhanh" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource DefaultForeground}"/>
                                     <Separator Margin="0,8"/>
 
-                                    <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                                        <TextBlock Text="Hàng:" Width="120" Foreground="{DynamicResource DefaultForeground}"/>
-                                        <ComboBox Width="120" ItemsSource="{Binding RowOptions}" SelectedItem="{Binding SelectedRows}"/>
-                                    </StackPanel>
-
-                                    <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                                        <TextBlock Text="Cột:" Width="120" Foreground="{DynamicResource DefaultForeground}"/>
-                                        <ComboBox Width="120" ItemsSource="{Binding ColumnOptions}" SelectedItem="{Binding SelectedColumns}"/>
-                                    </StackPanel>
-
                                     <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                                         <TextBlock Text="Người đi trước:" Width="120" Foreground="{DynamicResource DefaultForeground}"/>
                                         <ComboBox Width="120" ItemsSource="{Binding Players}" SelectedItem="{Binding FirstPlayer}"/>
@@ -58,7 +48,7 @@
                                               IsChecked="{Binding IsAIEnabled}" Foreground="{DynamicResource DefaultForeground}"/>
 
                                     <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-                                        <TextBlock Text="Chế độ:" Width="120" Foreground="{DynamicResource DefaultForeground}"/>
+                                        <TextBlock Text="Cấp độ:" Width="120" Foreground="{DynamicResource DefaultForeground}"/>
                                         <ComboBox Width="120"
                                                   ItemsSource="{Binding AIModes}"
                                                   SelectedItem="{Binding SelectedAIMode}"/>
@@ -181,7 +171,7 @@
                                 <TextBlock Text="Luật chơi cơ bản" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource DefaultForeground}"/>
                                 <Separator Margin="0,8"/>
                                 <TextBlock Text="• Mục tiêu: đạt 5 quân liên tiếp theo hàng ngang, dọc, hoặc chéo." Foreground="{DynamicResource DefaultForeground}"/>
-                                <TextBlock Text="• Bàn cờ: lưới N×M, có thể tùy chỉnh số hàng/cột." Margin="0,6,0,0" Foreground="{DynamicResource DefaultForeground}"/>
+                                <TextBlock Text="• Bàn cờ: khởi tạo 30×30 và sẽ tự mở rộng khi đánh gần rìa." Margin="0,6,0,0" Foreground="{DynamicResource DefaultForeground}"/>
                                 <TextBlock Text="• Lượt đi: X và O thay phiên nhau." Margin="0,6,0,0" Foreground="{DynamicResource DefaultForeground}"/>
                                 <TextBlock Text="• Thắng: khi một bên có 5 quân liên tiếp." Margin="0,6,0,0" Foreground="{DynamicResource DefaultForeground}"/>
                                 <Separator Margin="0,8"/>


### PR DESCRIPTION
## Summary
- replace the old board size selection with level-based presets and rename the master level to "Chuyên nghiệp"
- default easy and hard games to a 30x30 board that auto-expands when moves reach the edge so AI can respond around new spaces
- keep the professional AI behaviour while updating save/load handling and on-screen guidance to reflect the new defaults

## Testing
- dotnet build *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da5bfabbd48322817892cdbf2c73e3