### PR TITLE
Prevent AI search animation

### DIFF
--- a/Models/Cell.cs
+++ b/Models/Cell.cs
@@ -17,7 +17,7 @@ namespace Caro_game.Models
         public string Value
         {
             get => _value;
-            set { _value = value; OnPropertyChanged(); }
+            set => SetValue(value);
         }
 
         public bool IsWinningCell
@@ -35,6 +35,21 @@ namespace Caro_game.Models
             Value = string.Empty;
             IsWinningCell = false;
             ClickCommand = new RelayCommand(o => board.MakeMove(this));
+        }
+
+        public void SetValue(string value, bool notify = true)
+        {
+            if (_value == value)
+            {
+                return;
+            }
+
+            _value = value;
+
+            if (notify)
+            {
+                OnPropertyChanged(nameof(Value));
+            }
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/ViewModels/BoardViewModel/BoardViewModel.AI.cs
+++ b/ViewModels/BoardViewModel/BoardViewModel.AI.cs
@@ -77,13 +77,13 @@ namespace Caro_game.ViewModels
 
             foreach (var cell in candidates)
             {
-                cell.Value = AiSymbol;
+                cell.SetValue(AiSymbol, notify: false);
 
                 int score = CheckWin(cell.Row, cell.Col, AiSymbol)
                     ? WinningScore
                     : Minimax(SearchDepth - 1, maximizingPlayer: false, lastMove: cell, alpha: int.MinValue + 1, beta: int.MaxValue - 1);
 
-                cell.Value = string.Empty;
+                cell.SetValue(string.Empty, notify: false);
 
                 if (score > bestScore)
                 {
@@ -143,9 +143,9 @@ namespace Caro_game.ViewModels
 
                 foreach (var move in candidates)
                 {
-                    move.Value = AiSymbol;
+                    move.SetValue(AiSymbol, notify: false);
                     int evaluation = Minimax(depth - 1, false, move, alpha, beta);
-                    move.Value = string.Empty;
+                    move.SetValue(string.Empty, notify: false);
 
                     if (evaluation > value)
                     {
@@ -164,9 +164,9 @@ namespace Caro_game.ViewModels
 
                 foreach (var move in candidates)
                 {
-                    move.Value = HumanSymbol;
+                    move.SetValue(HumanSymbol, notify: false);
                     int evaluation = Minimax(depth - 1, true, move, alpha, beta);
-                    move.Value = string.Empty;
+                    move.SetValue(string.Empty, notify: false);
 
                     if (evaluation < value)
                     {


### PR DESCRIPTION
## Summary
- add an optional notification-aware setter on `Cell` so the board value can be updated without UI broadcasts
- use the silent setter while the easy and hard AI modes simulate moves, preventing their search from flashing on the board

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68da84e824c4832286556333f9d747f5