### PR TITLE
Allow human or AI to take the first move

### DIFF
--- a/Models/Cell.cs
+++ b/Models/Cell.cs
@@ -10,6 +10,7 @@ namespace Caro_game.Models
     {
         private string _value;
         private bool _isWinningCell;
+        private bool _isLastMove;
 
         public int Row { get; set; }
         public int Col { get; set; }
@@ -26,6 +27,12 @@ namespace Caro_game.Models
             set { _isWinningCell = value; OnPropertyChanged(); }
         }
 
+        public bool IsLastMove
+        {
+            get => _isLastMove;
+            set { _isLastMove = value; OnPropertyChanged(); }
+        }
+
         public ICommand ClickCommand { get; set; }
 
         public Cell(int row, int col, BoardViewModel board)
@@ -34,6 +41,7 @@ namespace Caro_game.Models
             Col = col;
             Value = string.Empty;
             IsWinningCell = false;
+            IsLastMove = false;
             ClickCommand = new RelayCommand(_ => board.MakeHumanMove(this));
         }
 

--- a/Models/Cell.cs
+++ b/Models/Cell.cs
@@ -34,7 +34,7 @@ namespace Caro_game.Models
             Col = col;
             Value = string.Empty;
             IsWinningCell = false;
-            ClickCommand = new RelayCommand(o => board.MakeMove(this));
+            ClickCommand = new RelayCommand(_ => board.MakeHumanMove(this));
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/Models/GameState.cs
+++ b/Models/GameState.cs
@@ -9,6 +9,7 @@ namespace Caro_game.Models
         public int Columns { get; set; }
         public string? FirstPlayer { get; set; }
         public string? CurrentPlayer { get; set; }
+        public string? HumanSymbol { get; set; }
         public bool IsAIEnabled { get; set; }
         public string? AIMode { get; set; }
         public int TimeLimitMinutes { get; set; }

--- a/Models/GameState.cs
+++ b/Models/GameState.cs
@@ -17,5 +17,10 @@ namespace Caro_game.Models
         public bool IsPaused { get; set; }
         public DateTime SavedAt { get; set; }
         public List<CellState> Cells { get; set; } = new();
+        public int? LastMoveRow { get; set; }
+        public int? LastMoveCol { get; set; }
+        public string? LastMovePlayer { get; set; }
+        public int? LastHumanMoveRow { get; set; }
+        public int? LastHumanMoveCol { get; set; }
     }
 }

--- a/Resources/Themes/DarkTheme.xaml
+++ b/Resources/Themes/DarkTheme.xaml
@@ -12,5 +12,6 @@
     <SolidColorBrush x:Key="CellBorderBrush" Color="#1F2937"/>
     <SolidColorBrush x:Key="AccentForegroundBrush" Color="#C7D2FE"/>
     <SolidColorBrush x:Key="MutedForegroundBrush" Color="#9CA3AF"/>
+    <SolidColorBrush x:Key="LastMoveBrush" Color="#1D4ED8"/>
     <SolidColorBrush x:Key="WinningCellBrush" Color="#FACC15"/>
 </ResourceDictionary>

--- a/Resources/Themes/LightTheme.xaml
+++ b/Resources/Themes/LightTheme.xaml
@@ -12,5 +12,6 @@
     <SolidColorBrush x:Key="CellBorderBrush" Color="#CBD5F5"/>
     <SolidColorBrush x:Key="AccentForegroundBrush" Color="#1E3A8A"/>
     <SolidColorBrush x:Key="MutedForegroundBrush" Color="#4B5563"/>
+    <SolidColorBrush x:Key="LastMoveBrush" Color="#BFDBFE"/>
     <SolidColorBrush x:Key="WinningCellBrush" Color="#F59E0B"/>
 </ResourceDictionary>

--- a/ViewModels/Board/BoardViewModel.Engine.cs
+++ b/ViewModels/Board/BoardViewModel.Engine.cs
@@ -42,7 +42,7 @@ public partial class BoardViewModel
             }
 
             // ✅ Fix: Kiểm tra Cells trước khi gọi All
-            if (Cells != null && Cells.All(c => string.IsNullOrEmpty(c.Value)) && CurrentPlayer == "O")
+            if (Cells != null && Cells.All(c => string.IsNullOrEmpty(c.Value)) && CurrentPlayer == _aiSymbol)
             {
                 var aiMove = _engine.Begin();
                 PlaceAiIfValid(aiMove);

--- a/ViewModels/Board/BoardViewModel.State.cs
+++ b/ViewModels/Board/BoardViewModel.State.cs
@@ -17,6 +17,7 @@ public partial class BoardViewModel
         {
             cell.Value = string.Empty;
             cell.IsWinningCell = false;
+            cell.IsLastMove = false;
         }
 
         if (state.Cells != null)
@@ -29,6 +30,26 @@ public partial class BoardViewModel
                     cell.IsWinningCell = cellState.IsWinningCell;
                 }
             }
+        }
+
+        _lastMoveCell = null;
+        _lastHumanMoveCell = null;
+        _lastMovePlayer = null;
+
+        if (state.LastMoveRow.HasValue && state.LastMoveCol.HasValue &&
+            _cellLookup.TryGetValue((state.LastMoveRow.Value, state.LastMoveCol.Value), out var lastMove))
+        {
+            _lastMoveCell = lastMove;
+            _lastMovePlayer = string.IsNullOrWhiteSpace(state.LastMovePlayer)
+                ? null
+                : state.LastMovePlayer;
+            lastMove.IsLastMove = true;
+        }
+
+        if (state.LastHumanMoveRow.HasValue && state.LastHumanMoveCol.HasValue &&
+            _cellLookup.TryGetValue((state.LastHumanMoveRow.Value, state.LastHumanMoveCol.Value), out var lastHuman))
+        {
+            _lastHumanMoveCell = lastHuman;
         }
 
         if (!string.IsNullOrWhiteSpace(state.CurrentPlayer))

--- a/ViewModels/Board/BoardViewModel.cs
+++ b/ViewModels/Board/BoardViewModel.cs
@@ -44,6 +44,8 @@ public partial class BoardViewModel : BaseViewModel
     private readonly HashSet<(int Row, int Col)> _candidatePositions;
     private readonly object _candidateLock = new();
     private readonly string _initialPlayer;
+    private readonly string _humanSymbol;
+    private readonly string _aiSymbol;
 
     private string _currentPlayer;
     public string CurrentPlayer
@@ -111,19 +113,25 @@ public partial class BoardViewModel : BaseViewModel
     }
 
     public string InitialPlayer => _initialPlayer;
+    public string HumanSymbol => _humanSymbol;
+    public string AISymbol => _aiSymbol;
 
     private EngineClient? _engine;
 
     public event EventHandler<GameEndedEventArgs>? GameEnded;
 
-    public BoardViewModel(int rows, int columns, string firstPlayer, string aiMode = "Dễ")
+    public BoardViewModel(int rows, int columns, string firstPlayer, string aiMode = "Dễ", string? humanSymbol = null)
     {
         Rows = rows;
         Columns = columns;
         AIMode = aiMode;
-        CurrentPlayer = firstPlayer.StartsWith("X", StringComparison.OrdinalIgnoreCase) ? "X" : "O";
+        CurrentPlayer = firstPlayer.Equals("O", StringComparison.OrdinalIgnoreCase) ? "O" : "X";
 
         _initialPlayer = CurrentPlayer;
+        _humanSymbol = string.IsNullOrWhiteSpace(humanSymbol)
+            ? CurrentPlayer
+            : (humanSymbol.Equals("O", StringComparison.OrdinalIgnoreCase) ? "O" : "X");
+        _aiSymbol = _humanSymbol == "X" ? "O" : "X";
         Cells = new ObservableCollection<Cell>();
         _cellLookup = new Dictionary<(int, int), Cell>(rows * columns);
         _candidatePositions = new HashSet<(int, int)>();

--- a/ViewModels/Board/BoardViewModel.cs
+++ b/ViewModels/Board/BoardViewModel.cs
@@ -46,6 +46,10 @@ public partial class BoardViewModel : BaseViewModel
     private readonly string _initialPlayer;
     private readonly string _humanSymbol;
     private readonly string _aiSymbol;
+    private static readonly TimeSpan AiThinkingDelay = TimeSpan.FromMilliseconds(600);
+    private Cell? _lastMoveCell;
+    private Cell? _lastHumanMoveCell;
+    private string? _lastMovePlayer;
 
     private string _currentPlayer;
     public string CurrentPlayer
@@ -115,6 +119,13 @@ public partial class BoardViewModel : BaseViewModel
     public string InitialPlayer => _initialPlayer;
     public string HumanSymbol => _humanSymbol;
     public string AISymbol => _aiSymbol;
+    public (int Row, int Col)? LastMovePosition => _lastMoveCell != null
+        ? (_lastMoveCell.Row, _lastMoveCell.Col)
+        : null;
+    public (int Row, int Col)? LastHumanMovePosition => _lastHumanMoveCell != null
+        ? (_lastHumanMoveCell.Row, _lastHumanMoveCell.Col)
+        : null;
+    public string? LastMovePlayer => _lastMovePlayer;
 
     private EngineClient? _engine;
 

--- a/ViewModels/Main/MainViewModel.Game.cs
+++ b/ViewModels/Main/MainViewModel.Game.cs
@@ -14,12 +14,25 @@ public partial class MainViewModel
         int rows = baseSize;
         int cols = baseSize;
 
-        var board = new BoardViewModel(rows, cols, FirstPlayer, SelectedAIMode)
+        bool playerStarts = FirstPlayer switch
+        {
+            "Bạn đi trước" => true,
+            "Máy đi trước" => false,
+            "Ngẫu nhiên" => _random.Next(2) == 0,
+            _ => true
+        };
+
+        string startingSymbol = "X";
+        string humanSymbol = playerStarts ? startingSymbol : "O";
+
+        var board = new BoardViewModel(rows, cols, startingSymbol, SelectedAIMode, humanSymbol)
         {
             IsAIEnabled = IsAIEnabled
         };
 
         Board = board;
+
+        board.TryStartAITurn();
 
         _configuredDuration = SelectedTimeOption.Minutes > 0
             ? TimeSpan.FromMinutes(SelectedTimeOption.Minutes)

--- a/ViewModels/Main/MainViewModel.Persistence.cs
+++ b/ViewModels/Main/MainViewModel.Persistence.cs
@@ -33,6 +33,7 @@ public partial class MainViewModel
                 Columns = Board.Columns,
                 FirstPlayer = Board.InitialPlayer,
                 CurrentPlayer = Board.CurrentPlayer,
+                HumanSymbol = Board.HumanSymbol,
                 IsAIEnabled = Board.IsAIEnabled,
                 AIMode = Board.AIMode,
                 TimeLimitMinutes = SelectedTimeOption.Minutes,
@@ -96,7 +97,11 @@ public partial class MainViewModel
         IsGameActive = false;
         IsGamePaused = false;
 
-        FirstPlayer = state.FirstPlayer == "O" ? "O" : "X (Bạn)";
+        var humanSymbol = string.IsNullOrWhiteSpace(state.HumanSymbol)
+            ? "X"
+            : (state.HumanSymbol!.Equals("O", StringComparison.OrdinalIgnoreCase) ? "O" : "X");
+
+        FirstPlayer = humanSymbol == "O" ? "Máy đi trước" : "Bạn đi trước";
 
         IsAIEnabled = state.IsAIEnabled;
         var targetMode = string.IsNullOrWhiteSpace(state.AIMode) ? "Dễ" : state.AIMode!;
@@ -105,7 +110,7 @@ public partial class MainViewModel
         bool professionalModeRestored = state.IsAIEnabled && targetMode == "Chuyên nghiệp";
         var boardAIMode = professionalModeRestored ? "Khó" : targetMode;
 
-        var board = new BoardViewModel(state.Rows, state.Columns, state.FirstPlayer ?? "X", boardAIMode)
+        var board = new BoardViewModel(state.Rows, state.Columns, state.FirstPlayer ?? "X", boardAIMode, humanSymbol)
         {
             IsAIEnabled = professionalModeRestored ? false : state.IsAIEnabled
         };

--- a/ViewModels/Main/MainViewModel.Persistence.cs
+++ b/ViewModels/Main/MainViewModel.Persistence.cs
@@ -49,6 +49,22 @@ public partial class MainViewModel
                 }).ToList()
             };
 
+            var lastMove = Board.LastMovePosition;
+            if (lastMove.HasValue)
+            {
+                state.LastMoveRow = lastMove.Value.Row;
+                state.LastMoveCol = lastMove.Value.Col;
+            }
+
+            state.LastMovePlayer = Board.LastMovePlayer;
+
+            var lastHumanMove = Board.LastHumanMovePosition;
+            if (lastHumanMove.HasValue)
+            {
+                state.LastHumanMoveRow = lastHumanMove.Value.Row;
+                state.LastHumanMoveCol = lastHumanMove.Value.Col;
+            }
+
             var json = JsonSerializer.Serialize(state, new JsonSerializerOptions
             {
                 WriteIndented = true

--- a/ViewModels/Main/MainViewModel.cs
+++ b/ViewModels/Main/MainViewModel.cs
@@ -30,6 +30,7 @@ public partial class MainViewModel : INotifyPropertyChanged
     private string _statusMessage;
     private DispatcherTimer? _gameTimer;
     private TimeSpan _configuredDuration = TimeSpan.Zero;
+    private readonly Random _random = new();
 
     public ObservableCollection<string> Players { get; }
     public ObservableCollection<string> AIModes { get; }
@@ -216,7 +217,12 @@ public partial class MainViewModel : INotifyPropertyChanged
 
     public MainViewModel()
     {
-        Players = new ObservableCollection<string> { "X (Bạn)", "O" };
+        Players = new ObservableCollection<string>
+        {
+            "Bạn đi trước",
+            "Máy đi trước",
+            "Ngẫu nhiên"
+        };
         AIModes = new ObservableCollection<string> { "Dễ", "Khó", "Chuyên nghiệp" };
         TimeOptions = new ObservableCollection<TimeOption>
         {
@@ -230,7 +236,7 @@ public partial class MainViewModel : INotifyPropertyChanged
             new TimeOption(60, "60 phút")
         };
 
-        FirstPlayer = "X (Bạn)";
+        FirstPlayer = Players[0];
         IsAIEnabled = true;
         SelectedAIMode = "Khó";
 

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -4,17 +4,12 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="clr-namespace:Caro_game.ViewModels"
-        xmlns:conv="clr-namespace:Caro_game.Converters"
         mc:Ignorable="d"
         Title="Caro Game"
         Width="1000" Height="700"
         WindowStartupLocation="CenterScreen"
         Background="{DynamicResource WindowBackgroundBrush}"
         WindowState="Maximized">
-
-    <Window.Resources>
-        <conv:BoolToBrushConverter x:Key="BoolToBrushConverter"/>
-    </Window.Resources>
 
     <Window.DataContext>
         <vm:MainViewModel/>
@@ -146,10 +141,25 @@
                                                                 Margin="1"
                                                                 FontWeight="Bold"
                                                                 FontSize="16"
-                                                                Background="{Binding IsWinningCell, Converter={StaticResource BoolToBrushConverter}}"
-                                                                Foreground="{DynamicResource DefaultForeground}"
-                                                                BorderBrush="{DynamicResource CellBorderBrush}"
-                                                                BorderThickness="1"/>
+                                                                Foreground="{DynamicResource DefaultForeground}">
+                                                            <Button.Style>
+                                                                <Style TargetType="Button">
+                                                                    <Setter Property="Background" Value="{DynamicResource CellBackgroundBrush}"/>
+                                                                    <Setter Property="BorderBrush" Value="{DynamicResource CellBorderBrush}"/>
+                                                                    <Setter Property="BorderThickness" Value="1"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding IsLastMove}" Value="True">
+                                                                            <Setter Property="Background" Value="{DynamicResource LastMoveBrush}"/>
+                                                                            <Setter Property="BorderBrush" Value="{DynamicResource Primary}"/>
+                                                                            <Setter Property="BorderThickness" Value="2"/>
+                                                                        </DataTrigger>
+                                                                        <DataTrigger Binding="{Binding IsWinningCell}" Value="True">
+                                                                            <Setter Property="Background" Value="{DynamicResource WinningCellBrush}"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </Button.Style>
+                                                        </Button>
                                                     </DataTemplate>
                                                 </ItemsControl.ItemTemplate>
                                             </ItemsControl>


### PR DESCRIPTION
## Summary
- replace the first-player selector with options for the human, the AI, or a random choice while keeping X as the opening mark
- propagate the chosen starting side through the board state and save files so the human/AI assignment is preserved
- update move handling so AI logic honours the selected symbols and automatically plays when it should

## Testing
- `dotnet build` *(fails: `dotnet` command is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dac47a168c832286995e753535b935