### PR TITLE
Add rule selection and integrate professional engine configs

### DIFF
--- a/EngineClient.cs
+++ b/EngineClient.cs
@@ -12,7 +12,7 @@ namespace Caro_game
         private StreamReader? _output;
         private readonly string _logFile;
 
-        public EngineClient(string enginePath)
+        public EngineClient(string enginePath, string? configPath = null)
         {
             _logFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "engine_log.txt");
 
@@ -22,8 +22,15 @@ namespace Caro_game
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
                 UseShellExecute = false,
-                CreateNoWindow = true
+                CreateNoWindow = true,
+                WorkingDirectory = Path.GetDirectoryName(enginePath) ?? AppDomain.CurrentDomain.BaseDirectory
             };
+
+            if (!string.IsNullOrWhiteSpace(configPath))
+            {
+                psi.EnvironmentVariables["RAPFI_CONFIG_PATH"] = configPath;
+                Log($"[Init] Using config: {configPath}");
+            }
 
             _process = new Process { StartInfo = psi };
             _process.Start();

--- a/Models/GameRuleType.cs
+++ b/Models/GameRuleType.cs
@@ -1,0 +1,9 @@
+namespace Caro_game.Models
+{
+    public enum GameRuleType
+    {
+        Freestyle,
+        Standard,
+        Renju
+    }
+}

--- a/Models/GameState.cs
+++ b/Models/GameState.cs
@@ -12,6 +12,7 @@ namespace Caro_game.Models
         public string? HumanSymbol { get; set; }
         public bool IsAIEnabled { get; set; }
         public string? AIMode { get; set; }
+        public string? RuleName { get; set; }
         public int TimeLimitMinutes { get; set; }
         public int? RemainingSeconds { get; set; }
         public bool IsPaused { get; set; }

--- a/Models/RuleOption.cs
+++ b/Models/RuleOption.cs
@@ -1,0 +1,21 @@
+namespace Caro_game.Models
+{
+    public class RuleOption
+    {
+        public RuleOption(GameRuleType rule, string displayName, string description)
+        {
+            Rule = rule;
+            DisplayName = displayName;
+            Description = description;
+        }
+
+        public GameRuleType Rule { get; }
+
+        public string DisplayName { get; }
+
+        public string Description { get; }
+
+        public override string ToString()
+            => DisplayName;
+    }
+}

--- a/ViewModels/Board/BoardViewModel.cs
+++ b/ViewModels/Board/BoardViewModel.cs
@@ -51,6 +51,7 @@ public partial class BoardViewModel : BaseViewModel
     private Cell? _lastMoveCell;
     private Cell? _lastHumanMoveCell;
     private string? _lastMovePlayer;
+    private MoveSnapshot? _pendingProfessionalValidation;
 
     private string _currentPlayer;
     public string CurrentPlayer
@@ -172,5 +173,33 @@ public partial class BoardViewModel : BaseViewModel
         {
             TryInitializeProfessionalEngine();
         }
+    }
+
+    private sealed class MoveSnapshot
+    {
+        public MoveSnapshot(Cell cell,
+            string? previousValue,
+            bool previousIsLastMove,
+            Cell? previousLastMoveCell,
+            string? previousLastMovePlayer,
+            Cell? previousLastHumanMoveCell,
+            string previousCurrentPlayer)
+        {
+            Cell = cell;
+            PreviousValue = previousValue;
+            PreviousIsLastMove = previousIsLastMove;
+            PreviousLastMoveCell = previousLastMoveCell;
+            PreviousLastMovePlayer = previousLastMovePlayer;
+            PreviousLastHumanMoveCell = previousLastHumanMoveCell;
+            PreviousCurrentPlayer = previousCurrentPlayer;
+        }
+
+        public Cell Cell { get; }
+        public string? PreviousValue { get; }
+        public bool PreviousIsLastMove { get; }
+        public Cell? PreviousLastMoveCell { get; }
+        public string? PreviousLastMovePlayer { get; }
+        public Cell? PreviousLastHumanMoveCell { get; }
+        public string PreviousCurrentPlayer { get; }
     }
 }

--- a/ViewModels/Board/BoardViewModel.cs
+++ b/ViewModels/Board/BoardViewModel.cs
@@ -44,6 +44,7 @@ public partial class BoardViewModel : BaseViewModel
     private readonly HashSet<(int Row, int Col)> _candidatePositions;
     private readonly object _candidateLock = new();
     private readonly string _initialPlayer;
+    private readonly GameRuleType _rule;
     private readonly string _humanSymbol;
     private readonly string _aiSymbol;
     private static readonly TimeSpan AiThinkingDelay = TimeSpan.FromMilliseconds(600);
@@ -75,6 +76,15 @@ public partial class BoardViewModel : BaseViewModel
             {
                 _isAIEnabled = value;
                 OnPropertyChanged();
+
+                if (_isAIEnabled && AIMode == "Chuyên nghiệp")
+                {
+                    TryInitializeProfessionalEngine();
+                }
+                else if (!_isAIEnabled)
+                {
+                    DisposeEngine();
+                }
             }
         }
     }
@@ -119,6 +129,7 @@ public partial class BoardViewModel : BaseViewModel
     public string InitialPlayer => _initialPlayer;
     public string HumanSymbol => _humanSymbol;
     public string AISymbol => _aiSymbol;
+    public GameRuleType Rule => _rule;
     public (int Row, int Col)? LastMovePosition => _lastMoveCell != null
         ? (_lastMoveCell.Row, _lastMoveCell.Col)
         : null;
@@ -131,7 +142,7 @@ public partial class BoardViewModel : BaseViewModel
 
     public event EventHandler<GameEndedEventArgs>? GameEnded;
 
-    public BoardViewModel(int rows, int columns, string firstPlayer, string aiMode = "Dễ", string? humanSymbol = null)
+    public BoardViewModel(int rows, int columns, string firstPlayer, string aiMode = "Dễ", string? humanSymbol = null, GameRuleType rule = GameRuleType.Freestyle)
     {
         Rows = rows;
         Columns = columns;
@@ -139,6 +150,7 @@ public partial class BoardViewModel : BaseViewModel
         CurrentPlayer = firstPlayer.Equals("O", StringComparison.OrdinalIgnoreCase) ? "O" : "X";
 
         _initialPlayer = CurrentPlayer;
+        _rule = rule;
         _humanSymbol = string.IsNullOrWhiteSpace(humanSymbol)
             ? CurrentPlayer
             : (humanSymbol.Equals("O", StringComparison.OrdinalIgnoreCase) ? "O" : "X");

--- a/ViewModels/Main/MainViewModel.Game.cs
+++ b/ViewModels/Main/MainViewModel.Game.cs
@@ -10,9 +10,9 @@ public partial class MainViewModel
     private void StartGame(object? parameter)
     {
         bool isProfessionalMode = SelectedAIMode == "Chuyên nghiệp";
-        int baseSize = isProfessionalMode ? 19 : 35;
-        int rows = baseSize;
-        int cols = baseSize;
+        var rule = SelectedRule;
+        int rows = rule == GameRuleType.Freestyle ? 19 : 15;
+        int cols = rows;
 
         bool playerStarts = FirstPlayer switch
         {
@@ -25,7 +25,7 @@ public partial class MainViewModel
         string startingSymbol = "X";
         string humanSymbol = playerStarts ? startingSymbol : "O";
 
-        var board = new BoardViewModel(rows, cols, startingSymbol, SelectedAIMode, humanSymbol)
+        var board = new BoardViewModel(rows, cols, startingSymbol, SelectedAIMode, humanSymbol, rule)
         {
             IsAIEnabled = IsAIEnabled
         };
@@ -33,6 +33,16 @@ public partial class MainViewModel
         Board = board;
 
         board.TryStartAITurn();
+
+        if (isProfessionalMode && IsAIEnabled)
+        {
+            MessageBox.Show(
+                $"Chế độ chuyên nghiệp - {SelectedRuleOption.DisplayName}.\n" +
+                "Engine Rapfi sẽ tự kiểm tra luật. Quân X luôn được xem là quân đen.",
+                "Chuyên nghiệp",
+                MessageBoxButton.OK,
+                MessageBoxImage.Information);
+        }
 
         _configuredDuration = SelectedTimeOption.Minutes > 0
             ? TimeSpan.FromMinutes(SelectedTimeOption.Minutes)

--- a/ViewModels/Main/MainViewModel.Persistence.cs
+++ b/ViewModels/Main/MainViewModel.Persistence.cs
@@ -27,20 +27,21 @@ public partial class MainViewModel
 
         if (dialog.ShowDialog() == true)
         {
-            var state = new GameState
-            {
-                Rows = Board.Rows,
-                Columns = Board.Columns,
-                FirstPlayer = Board.InitialPlayer,
-                CurrentPlayer = Board.CurrentPlayer,
-                HumanSymbol = Board.HumanSymbol,
-                IsAIEnabled = Board.IsAIEnabled,
-                AIMode = Board.AIMode,
-                TimeLimitMinutes = SelectedTimeOption.Minutes,
-                RemainingSeconds = SelectedTimeOption.Minutes > 0 ? (int?)Math.Ceiling(RemainingTime.TotalSeconds) : null,
-                IsPaused = IsGamePaused,
-                SavedAt = DateTime.Now,
-                Cells = Board.Cells.Select(c => new CellState
+                var state = new GameState
+                {
+                    Rows = Board.Rows,
+                    Columns = Board.Columns,
+                    FirstPlayer = Board.InitialPlayer,
+                    CurrentPlayer = Board.CurrentPlayer,
+                    HumanSymbol = Board.HumanSymbol,
+                    IsAIEnabled = Board.IsAIEnabled,
+                    AIMode = Board.AIMode,
+                    RuleName = Board.Rule.ToString(),
+                    TimeLimitMinutes = SelectedTimeOption.Minutes,
+                    RemainingSeconds = SelectedTimeOption.Minutes > 0 ? (int?)Math.Ceiling(RemainingTime.TotalSeconds) : null,
+                    IsPaused = IsGamePaused,
+                    SavedAt = DateTime.Now,
+                    Cells = Board.Cells.Select(c => new CellState
                 {
                     Row = c.Row,
                     Col = c.Col,
@@ -123,10 +124,22 @@ public partial class MainViewModel
         var targetMode = string.IsNullOrWhiteSpace(state.AIMode) ? "Dễ" : state.AIMode!;
         SelectedAIMode = targetMode;
 
+        var ruleType = GameRuleType.Freestyle;
+        if (!string.IsNullOrWhiteSpace(state.RuleName) && Enum.TryParse(state.RuleName, true, out GameRuleType parsedRule))
+        {
+            ruleType = parsedRule;
+        }
+        else if (state.Rows == 15)
+        {
+            ruleType = GameRuleType.Standard;
+        }
+
+        SelectedRuleOption = RuleOptions.FirstOrDefault(r => r.Rule == ruleType) ?? RuleOptions[0];
+
         bool professionalModeRestored = state.IsAIEnabled && targetMode == "Chuyên nghiệp";
         var boardAIMode = professionalModeRestored ? "Khó" : targetMode;
 
-        var board = new BoardViewModel(state.Rows, state.Columns, state.FirstPlayer ?? "X", boardAIMode, humanSymbol)
+        var board = new BoardViewModel(state.Rows, state.Columns, state.FirstPlayer ?? "X", boardAIMode, humanSymbol, ruleType)
         {
             IsAIEnabled = professionalModeRestored ? false : state.IsAIEnabled
         };

--- a/ViewModels/Main/MainViewModel.cs
+++ b/ViewModels/Main/MainViewModel.cs
@@ -21,6 +21,7 @@ public partial class MainViewModel : INotifyPropertyChanged
     private BoardViewModel? _board;
     private bool _isAIEnabled;
     private string _selectedAIMode;
+    private RuleOption _selectedRuleOption;
     private TimeOption _selectedTimeOption;
     private string _selectedTheme;
     private bool _isSoundEnabled;
@@ -35,6 +36,7 @@ public partial class MainViewModel : INotifyPropertyChanged
     public ObservableCollection<string> Players { get; }
     public ObservableCollection<string> AIModes { get; }
     public ObservableCollection<TimeOption> TimeOptions { get; }
+    public ObservableCollection<RuleOption> RuleOptions { get; }
 
     public ObservableCollection<string> Themes { get; } =
         new ObservableCollection<string> { DefaultDarkThemeLabel, "Light" };
@@ -86,6 +88,25 @@ public partial class MainViewModel : INotifyPropertyChanged
             }
         }
     }
+
+    public RuleOption SelectedRuleOption
+    {
+        get => _selectedRuleOption;
+        set
+        {
+            if (_selectedRuleOption != value)
+            {
+                _selectedRuleOption = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(SelectedRule));
+                OnPropertyChanged(nameof(SelectedRuleDescription));
+            }
+        }
+    }
+
+    public GameRuleType SelectedRule => SelectedRuleOption?.Rule ?? GameRuleType.Freestyle;
+
+    public string SelectedRuleDescription => SelectedRuleOption?.Description ?? string.Empty;
 
     public string SelectedAIMode
     {
@@ -224,6 +245,12 @@ public partial class MainViewModel : INotifyPropertyChanged
             "Ngẫu nhiên"
         };
         AIModes = new ObservableCollection<string> { "Dễ", "Khó", "Chuyên nghiệp" };
+        RuleOptions = new ObservableCollection<RuleOption>
+        {
+            new RuleOption(GameRuleType.Freestyle, "Freestyle (19×19)", "Luật tự do, đạt 5 quân liên tiếp hoặc hơn đều thắng."),
+            new RuleOption(GameRuleType.Standard, "Gomoku chuẩn (15×15)", "Chỉ đúng 5 quân liên tiếp mới thắng."),
+            new RuleOption(GameRuleType.Renju, "Renju (15×15)", "Luật quốc tế với các hạn chế cho quân đen (X).")
+        };
         TimeOptions = new ObservableCollection<TimeOption>
         {
             new TimeOption(0, "Không giới hạn"),
@@ -239,6 +266,7 @@ public partial class MainViewModel : INotifyPropertyChanged
         FirstPlayer = Players[0];
         IsAIEnabled = true;
         SelectedAIMode = "Khó";
+        SelectedRuleOption = RuleOptions[0];
 
         SelectedTheme = DefaultDarkThemeLabel;
         IsSoundEnabled = true;

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -50,6 +50,18 @@
                                     </StackPanel>
 
                                     <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                                        <TextBlock Text="Luật chơi:" Width="120" Foreground="{DynamicResource DefaultForeground}"/>
+                                        <ComboBox Width="140"
+                                                  ItemsSource="{Binding RuleOptions}"
+                                                  SelectedItem="{Binding SelectedRuleOption}"/>
+                                    </StackPanel>
+
+                                    <TextBlock Text="{Binding SelectedRuleDescription}"
+                                               TextWrapping="Wrap"
+                                               Margin="0,4,0,0"
+                                               Foreground="{DynamicResource MutedForegroundBrush}"/>
+
+                                    <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                                         <TextBlock Text="Thời gian (phút):" Width="120" Foreground="{DynamicResource DefaultForeground}"/>
                                         <ComboBox Width="120"
                                                   ItemsSource="{Binding TimeOptions}"
@@ -181,7 +193,8 @@
 
                                 <TextBlock Text="• Mục tiêu: đạt 5 quân liên tiếp theo hàng ngang, dọc hoặc chéo." Foreground="{DynamicResource DefaultForeground}"/>
                                 <TextBlock Text="• Lượt đi: X luôn đi trước, O đi sau." Margin="0,6,0,0" Foreground="{DynamicResource DefaultForeground}"/>
-                                <TextBlock Text="• Bàn cờ: mặc định 30×30, phù hợp chơi freestyle." Margin="0,6,0,0" Foreground="{DynamicResource DefaultForeground}"/>
+                                <TextBlock Text="• Bàn cờ: Freestyle dùng bàn 19×19, các luật khác dùng bàn 15×15." Margin="0,6,0,0" Foreground="{DynamicResource DefaultForeground}"/>
+                                <TextBlock Text="• Quân X luôn được xem là quân đen trong mọi chế độ." Margin="0,4,0,0" Foreground="{DynamicResource DefaultForeground}"/>
 
                                 <Separator Margin="0,8"/>
                                 <TextBlock Text="Các biến thể luật" FontSize="16" FontWeight="Bold" Foreground="{DynamicResource AccentForegroundBrush}" Margin="0,6,0,0"/>


### PR DESCRIPTION
## Summary
- add Freestyle, Standard and Renju rule selection with updated UI, board sizing and saved state handling
- extend local win detection and AI heuristics to respect rule restrictions and basic Renju overline bans
- configure the professional Rapfi engine with rule-specific config files and ensure correct colour-based setup

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ddc26e5424832291449d07be78d707