### PR TITLE
Adjust freestyle board expansion for offline play

### DIFF
--- a/ViewModels/Main/MainViewModel.Game.cs
+++ b/ViewModels/Main/MainViewModel.Game.cs
@@ -15,6 +15,7 @@ public partial class MainViewModel
         int rows = ruleOption.Rows;
         int cols = ruleOption.Columns;
         bool allowExpansion = ruleOption.AllowExpansion;
+        bool isFreestyle = string.Equals(ruleOption.Name, "Freestyle", StringComparison.OrdinalIgnoreCase);
 
         bool playerStarts = FirstPlayer switch
         {
@@ -24,9 +25,27 @@ public partial class MainViewModel
             _ => true
         };
 
+        if (!IsAIEnabled)
+        {
+            playerStarts = true;
+        }
+
         string startingSymbol = "X";
         string humanSymbol = playerStarts ? startingSymbol : "O";
         string aiSymbol = humanSymbol == "X" ? "O" : "X";
+
+        if (!IsAIEnabled)
+        {
+            humanSymbol = startingSymbol;
+            aiSymbol = "O";
+
+            if (isFreestyle)
+            {
+                rows = cols = 35;
+                allowExpansion = true;
+            }
+        }
+
         bool aiPlaysBlack = IsAIEnabled ? aiSymbol == "X" : true;
 
         ApplyRuleConfiguration(ruleOption, aiPlaysBlack);

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -34,7 +34,8 @@
                                     <TextBlock Text="Tùy chọn nhanh" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource DefaultForeground}"/>
                                     <Separator Margin="0,8"/>
 
-                                    <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                                    <StackPanel Orientation="Horizontal" Margin="0,10,0,0"
+                                                IsEnabled="{Binding IsAIEnabled}">
                                         <TextBlock Text="Người đi trước:" Width="120" Foreground="{DynamicResource DefaultForeground}"/>
                                         <ComboBox Width="120" ItemsSource="{Binding Players}" SelectedItem="{Binding FirstPlayer}"/>
                                     </StackPanel>
@@ -42,7 +43,8 @@
                                     <CheckBox Content="Chơi với máy" Margin="0,10,0,0"
                                               IsChecked="{Binding IsAIEnabled}" Foreground="{DynamicResource DefaultForeground}"/>
 
-                                    <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                                    <StackPanel Orientation="Horizontal" Margin="0,10,0,0"
+                                                IsEnabled="{Binding IsAIEnabled}">
                                         <TextBlock Text="Cấp độ:" Width="120" Foreground="{DynamicResource DefaultForeground}"/>
                                         <ComboBox Width="120"
                                                   ItemsSource="{Binding AIModes}"


### PR DESCRIPTION
## Summary
- disable the first-player and difficulty selectors whenever AI play is turned off
- make freestyle games without AI start on a 35x35 board that can expand at the edges

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de71e47f608322ace56044d7a3231e