### PR TITLE
Preserve saved game configuration when loading

### DIFF
--- a/Models/GameState.cs
+++ b/Models/GameState.cs
@@ -13,7 +13,9 @@ namespace Caro_game.Models
         public string? Rule { get; set; }
         public bool IsAIEnabled { get; set; }
         public string? AIMode { get; set; }
+        public string? FirstPlayerSelection { get; set; }
         public int TimeLimitMinutes { get; set; }
+        public string? TimeOptionDisplay { get; set; }
         public int? RemainingSeconds { get; set; }
         public bool IsPaused { get; set; }
         public DateTime SavedAt { get; set; }


### PR DESCRIPTION
## Summary
- capture the player's first-move choice and time option label when saving a game
- restore saved games with their original AI mode, rule, and timer configuration without downgrading the difficulty
- show a confirmation message that includes the restored mode, level, and time information when loading a save

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de75ac952483229b4e6177fc85fc47