### PR TITLE
Persist move order and sync professional AI

### DIFF
--- a/AI/config.toml
+++ b/AI/config.toml
@@ -47,9 +47,8 @@ draw_ratio = 1.0
 # The path of weights for different board sizes and rules. Weights are searched in order.
 # For mix9svqnnue
 [[model.evaluator.weights]]
-weight_file = "mix9svqfreestyle_bsmix.bin.lz4"
-
-
+weight_file_white = "mix9svqrenju_bs15_white.bin.lz4"
+weight_file_black = "mix9svqrenju_bs15_black.bin.lz4"
 
 [search]
 # Whether to enable aspiration window

--- a/EngineClient.cs
+++ b/EngineClient.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
 namespace Caro_game
@@ -120,21 +118,6 @@ namespace Caro_game
                     _process.Kill(true);
             }
             catch { }
-        }
-
-        public string? SyncBoard(IEnumerable<(int X, int Y, int Player)> moves)
-        {
-            Send("BOARD");
-
-            foreach (var move in moves)
-            {
-                Send($"{move.X},{move.Y},{move.Player}");
-            }
-
-            Send("DONE");
-
-            var response = ReceiveLine();
-            return string.IsNullOrWhiteSpace(response) ? null : response;
         }
 
         public void Dispose()

--- a/EngineClient.cs
+++ b/EngineClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -119,6 +120,21 @@ namespace Caro_game
                     _process.Kill(true);
             }
             catch { }
+        }
+
+        public string? SyncBoard(IEnumerable<(int X, int Y, int Player)> moves)
+        {
+            Send("BOARD");
+
+            foreach (var move in moves)
+            {
+                Send($"{move.X},{move.Y},{move.Player}");
+            }
+
+            Send("DONE");
+
+            var response = ReceiveLine();
+            return string.IsNullOrWhiteSpace(response) ? null : response;
         }
 
         public void Dispose()

--- a/Models/GameState.cs
+++ b/Models/GameState.cs
@@ -18,6 +18,7 @@ namespace Caro_game.Models
         public bool IsPaused { get; set; }
         public DateTime SavedAt { get; set; }
         public List<CellState> Cells { get; set; } = new();
+        public List<MoveState> Moves { get; set; } = new();
         public int? LastMoveRow { get; set; }
         public int? LastMoveCol { get; set; }
         public string? LastMovePlayer { get; set; }

--- a/Models/MoveState.cs
+++ b/Models/MoveState.cs
@@ -1,0 +1,9 @@
+namespace Caro_game.Models
+{
+    public class MoveState
+    {
+        public int Row { get; set; }
+        public int Col { get; set; }
+        public string? Player { get; set; }
+    }
+}

--- a/ViewModels/Board/BoardViewModel.State.cs
+++ b/ViewModels/Board/BoardViewModel.State.cs
@@ -100,8 +100,10 @@ public partial class BoardViewModel
 
         if (AIMode == "Chuyên nghiệp" && IsAIEnabled)
         {
-            SyncProfessionalEngineWithMoves();
+            RestoreProfessionalEngineStateFromHistory();
         }
+
+        _isRestoringState = false;
     }
 
     private void RebuildCandidatePositions()

--- a/ViewModels/Board/BoardViewModel.cs
+++ b/ViewModels/Board/BoardViewModel.cs
@@ -50,6 +50,7 @@ public partial class BoardViewModel : BaseViewModel
     private readonly string _aiSymbol;
     private readonly IRule _rule;
     private readonly bool _allowBoardExpansion;
+    private bool _isRestoringState;
     private static readonly TimeSpan AiThinkingDelay = TimeSpan.FromSeconds(2);
     private Cell? _lastMoveCell;
     private Cell? _lastHumanMoveCell;
@@ -134,6 +135,7 @@ public partial class BoardViewModel : BaseViewModel
     public IReadOnlyList<MoveState> MoveHistory => _moveHistory;
 
     private EngineClient? _engine;
+    private bool _pendingResumeAfterLoad;
 
     public event EventHandler<GameEndedEventArgs>? GameEnded;
 
@@ -145,7 +147,8 @@ public partial class BoardViewModel : BaseViewModel
         string? humanSymbol = null,
         IRule? rule = null,
         string? ruleName = null,
-        bool allowBoardExpansion = false)
+        bool allowBoardExpansion = false,
+        bool isRestoringState = false)
     {
         Rows = rows;
         Columns = columns;
@@ -160,6 +163,7 @@ public partial class BoardViewModel : BaseViewModel
         _rule = (rule ?? new FreestyleRule()).Clone();
         RuleName = string.IsNullOrWhiteSpace(ruleName) ? "Freestyle" : ruleName!;
         _allowBoardExpansion = allowBoardExpansion;
+        _isRestoringState = isRestoringState;
         Cells = new ObservableCollection<Cell>();
         _cellLookup = new Dictionary<(int, int), Cell>(rows * columns);
         _candidatePositions = new HashSet<(int, int)>();

--- a/ViewModels/Board/BoardViewModel.cs
+++ b/ViewModels/Board/BoardViewModel.cs
@@ -43,6 +43,7 @@ public partial class BoardViewModel : BaseViewModel
 
     private readonly Dictionary<(int Row, int Col), Cell> _cellLookup;
     private readonly HashSet<(int Row, int Col)> _candidatePositions;
+    private readonly List<MoveState> _moveHistory;
     private readonly object _candidateLock = new();
     private readonly string _initialPlayer;
     private readonly string _humanSymbol;
@@ -130,6 +131,7 @@ public partial class BoardViewModel : BaseViewModel
         ? (_lastHumanMoveCell.Row, _lastHumanMoveCell.Col)
         : null;
     public string? LastMovePlayer => _lastMovePlayer;
+    public IReadOnlyList<MoveState> MoveHistory => _moveHistory;
 
     private EngineClient? _engine;
 
@@ -161,6 +163,7 @@ public partial class BoardViewModel : BaseViewModel
         Cells = new ObservableCollection<Cell>();
         _cellLookup = new Dictionary<(int, int), Cell>(rows * columns);
         _candidatePositions = new HashSet<(int, int)>();
+        _moveHistory = new List<MoveState>();
 
         for (int i = 0; i < rows * columns; i++)
         {

--- a/ViewModels/Board/BoardViewModel.cs
+++ b/ViewModels/Board/BoardViewModel.cs
@@ -43,7 +43,7 @@ public partial class BoardViewModel : BaseViewModel
 
     private readonly Dictionary<(int Row, int Col), Cell> _cellLookup;
     private readonly HashSet<(int Row, int Col)> _candidatePositions;
-    private readonly List<MoveState> _moveHistory;
+    private readonly List<MoveState> _moveHistory = new();
     private readonly object _candidateLock = new();
     private readonly string _initialPlayer;
     private readonly string _humanSymbol;
@@ -163,7 +163,6 @@ public partial class BoardViewModel : BaseViewModel
         Cells = new ObservableCollection<Cell>();
         _cellLookup = new Dictionary<(int, int), Cell>(rows * columns);
         _candidatePositions = new HashSet<(int, int)>();
-        _moveHistory = new List<MoveState>();
 
         for (int i = 0; i < rows * columns; i++)
         {

--- a/ViewModels/Main/MainViewModel.Persistence.cs
+++ b/ViewModels/Main/MainViewModel.Persistence.cs
@@ -47,6 +47,12 @@ public partial class MainViewModel
                     Col = c.Col,
                     Value = c.Value,
                     IsWinningCell = c.IsWinningCell
+                }).ToList(),
+                Moves = Board.MoveHistory.Select(m => new MoveState
+                {
+                    Row = m.Row,
+                    Col = m.Col,
+                    Player = m.Player
                 }).ToList()
             };
 
@@ -124,29 +130,18 @@ public partial class MainViewModel
         var targetMode = string.IsNullOrWhiteSpace(state.AIMode) ? "Dễ" : state.AIMode!;
         SelectedAIMode = targetMode;
 
-        bool professionalModeRestored = state.IsAIEnabled && targetMode == "Chuyên nghiệp";
-        var boardAIMode = professionalModeRestored ? "Khó" : targetMode;
-
         var ruleOption = ResolveRuleOption(state.Rule);
         SelectedRuleOption = ruleOption;
         var ruleInstance = ruleOption.CreateRule();
 
-        var board = new BoardViewModel(state.Rows, state.Columns, state.FirstPlayer ?? "X", boardAIMode, humanSymbol, ruleInstance, ruleOption.Name, ruleOption.AllowExpansion)
+        var board = new BoardViewModel(state.Rows, state.Columns, state.FirstPlayer ?? "X", targetMode, humanSymbol, ruleInstance, ruleOption.Name, ruleOption.AllowExpansion)
         {
-            IsAIEnabled = professionalModeRestored ? false : state.IsAIEnabled
+            IsAIEnabled = state.IsAIEnabled
         };
 
         board.LoadFromState(state);
 
         Board = board;
-
-        if (professionalModeRestored)
-        {
-            SelectedAIMode = "Khó";
-            IsAIEnabled = false;
-            MessageBox.Show("Không thể tiếp tục cấp độ AI Chuyên nghiệp cho ván đã lưu. Cấp độ đã được chuyển về Khó.",
-                "Thông báo", MessageBoxButton.OK, MessageBoxImage.Warning);
-        }
 
         var option = EnsureTimeOption(state.TimeLimitMinutes);
         SelectedTimeOption = option;

--- a/ViewModels/Main/MainViewModel.Persistence.cs
+++ b/ViewModels/Main/MainViewModel.Persistence.cs
@@ -134,7 +134,7 @@ public partial class MainViewModel
         SelectedRuleOption = ruleOption;
         var ruleInstance = ruleOption.CreateRule();
 
-        var board = new BoardViewModel(state.Rows, state.Columns, state.FirstPlayer ?? "X", targetMode, humanSymbol, ruleInstance, ruleOption.Name, ruleOption.AllowExpansion)
+        var board = new BoardViewModel(state.Rows, state.Columns, state.FirstPlayer ?? "X", targetMode, humanSymbol, ruleInstance, ruleOption.Name, ruleOption.AllowExpansion, isRestoringState: true)
         {
             IsAIEnabled = state.IsAIEnabled
         };
@@ -168,6 +168,7 @@ public partial class MainViewModel
         if (Board != null)
         {
             Board.IsPaused = IsGamePaused || hasWinner;
+            Board.ResumePendingAiTurn();
         }
 
         if (_configuredDuration > TimeSpan.Zero && !IsGamePaused && !hasWinner)


### PR DESCRIPTION
## Summary
- record and persist the ordered move history when saving a game
- restore move sequences on load and synchronize the professional AI engine using BOARD commands
- retain the saved AI difficulty and prevent AI moves from targeting occupied cells

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dee2a223148322bada61fd02db2ef6